### PR TITLE
Update string.md as String literals aren't Strings

### DIFF
--- a/glossary/String.md
+++ b/glossary/String.md
@@ -2,3 +2,10 @@
 
 Strings are one of the primitive data types in JavaScript.
 They are sequences of characters and are used to represent text.
+They are copied into instances of the `String` class when needed automatically.
+
+```js
+var a = 'a'
+a.concat === String.prototype.concat // true
+a instanceof String // false
+```


### PR DESCRIPTION
String literals get copied into String instances when needed automatically.

This could probably be in a completely different file instead with an example of each type of literal being coerced into an instance

<!--- Provide a general summary of your changes in the Title above -->

<!--- Add the prefix [FIX: #(issue number)], [FEATURE] or [ENHANCEMENT] to the Title -->

## Description
<!--- Describe your changes in detail -->
Mentions #690 <!--- Delete if not a issue fix-->

Clarifies when a String Literal gets coerced into a Stirng instance even though it's not

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [ ] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have checked that the changes are working properly
- [ ] I have checked that there isn't any PR doing the same
- [ ] I have read the **CONTRIBUTING** document.
