### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+## Bug description 
+<!-- A clear and concise description of what the bug is. -->
+
+## Steps to reproduce
+<!-- Where did you encounter the bug/What code caused the bug to appear? -->
+
+## Expected behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem. -->
+
+## Environment
+<!-- Provide some information about your OS, Browser or mobile device (if applicable). -->

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,7 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+
+---
+
+## Description

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,7 +1,0 @@
----
-name: Custom issue template
-about: Describe this issue template's purpose here.
-
----
-
-## Description

--- a/.github/ISSUE_TEMPLATE/discussion.md
+++ b/.github/ISSUE_TEMPLATE/discussion.md
@@ -1,0 +1,8 @@
+---
+name: Discussion
+about: Discuss something with us
+
+---
+
+## Description
+<!-- A clear and concise description of what you want to discuss. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+## Description 
+<!-- A clear and concise description of what you want to happen. -->
+<!-- Provide sample code, useful information, possible solutions and examples whenever possible. -->


### PR DESCRIPTION
In reference to #730 

Simple, easy-to-use and less cluttered Issue templates. 

**Chore:** Remove the old `ISSUE_TEMPLATE.md` right after merging.