### PR TITLE
 [ENHANCEMENT] Simpler solution to mask using padStart

### DIFF
--- a/snippets/mask.md
+++ b/snippets/mask.md
@@ -7,8 +7,7 @@ Omit the second argument, `num`, to keep a default of `4` characters unmasked. I
 Omit the third argument, `mask`, to use a default character of `'*'` for the mask.
 
 ```js
-const mask = (cc, num = 4, mask = '*') =>
-  ('' + cc).slice(-num).padStart(('' + cc).length, mask);
+const mask = (cc, num = 4, mask = '*') => `${cc}`.slice(-num).padStart(`${cc}`.length, mask);
 ```
 
 ```js

--- a/snippets/mask.md
+++ b/snippets/mask.md
@@ -2,14 +2,13 @@
 
 Replaces all but the last `num` of characters with the specified mask character.
 
-Use `String.slice()` to grab the portion of the characters that need to be masked and use `String.replace()` with a regexp to replace every character with the mask character.
-Concatenate the masked characters with the remaining unmasked portion of the string.
+Use `String.slice()` to grab the portion of the characters that will remain unmasked and use `String.padStart()` to fill the beginning of the string with the mask character up to the original length.
 Omit the second argument, `num`, to keep a default of `4` characters unmasked. If `num` is negative, the unmasked characters will be at the start of the string.
 Omit the third argument, `mask`, to use a default character of `'*'` for the mask.
 
 ```js
 const mask = (cc, num = 4, mask = '*') =>
-  ('' + cc).slice(0, -num).replace(/./g, mask) + ('' + cc).slice(-num);
+  ('' + cc).slice(-num).padStart(('' + cc).length, mask);
 ```
 
 ```js

--- a/test/mask/mask.js
+++ b/test/mask/mask.js
@@ -1,3 +1,3 @@
 const mask = (cc, num = 4, mask = '*') =>
-  ('' + cc).slice(0, -num).replace(/./g, mask) + ('' + cc).slice(-num);
+  ('' + cc).slice(-num).padStart(('' + cc).length, mask);
 module.exports = mask;


### PR DESCRIPTION
## Description
As asked in https://github.com/30-seconds/30-seconds-of-interviews/pull/107#issuecomment-424019789, I'm making a pull request to the same changes merged in 30 seconds of interviews.

Using `String.padStart` we can make the `mask.md` snippet a bit simpler.

## What does your PR belong to?
- [ ] Website
- [x] Snippets
- [ ] General / Things regarding the repository (like CI Integration)
- [x] Tests

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking improvement of a snippet)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have checked that the changes are working properly
- [x] I have checked that there isn't any PR doing the same
- [x] I have read the **CONTRIBUTING** document.
