### PR TITLE
[FIX] Replace deprecated calls in atob and btoa

### DIFF
--- a/snippets/atob.md
+++ b/snippets/atob.md
@@ -5,7 +5,7 @@ Decodes a string of data which has been encoded using base-64 encoding.
 Create a `Buffer` for the given string with base-64 encoding and use `Buffer.toString('binary')` to return the decoded string.
 
 ```js
-const atob = str => new Buffer(str, 'base64').toString('binary');
+const atob = str => Buffer.from(str, 'base64').toString('binary');
 ```
 
 ```js

--- a/snippets/btoa.md
+++ b/snippets/btoa.md
@@ -5,7 +5,7 @@ Creates a base-64 encoded ASCII string from a String object in which each charac
 Create a `Buffer` for the given string with binary encoding and use `Buffer.toString('base64')` to return the encoded string.
 
 ```js
-const btoa = str => new Buffer(str, 'binary').toString('base64');
+const btoa = str => new Buffer.from(str, 'binary').toString('base64');
 ```
 
 ```js

--- a/test/atob/atob.js
+++ b/test/atob/atob.js
@@ -1,2 +1,2 @@
-const atob = str => new Buffer(str, 'base64').toString('binary');
+const atob = str => Buffer.from(str, 'base64').toString('binary');
 module.exports = atob;

--- a/test/btoa/btoa.js
+++ b/test/btoa/btoa.js
@@ -1,2 +1,2 @@
-const btoa = str => new Buffer(str, 'binary').toString('base64');
+const btoa = str => new Buffer.from(str, 'binary').toString('base64');
 module.exports = btoa;


### PR DESCRIPTION
## Description
Resolves #799.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document. 
