### PR TITLE
dropProperties snippet for array of objects

### DIFF
--- a/snippets/dropProperties.md
+++ b/snippets/dropProperties.md
@@ -1,0 +1,20 @@
+### dropProperties
+
+Removes properties (objects key-value pairs) of an array of objects.
+
+Use spread operator (`...`) to accept single or multiple properties keys (strings) for removal. Use `Array.prototype.map` to iterate through input properties keys for removal. Use `Array.prototype.forEach()` to mutate each object of the array. Use `delete` to remove the property from each object.
+
+```js
+const dropProperties = (objArr, ...propKeys) => {
+  propKeys.map(propKey => objArr.forEach(obj => delete obj[propKey]));
+  return objArr;
+};
+```
+
+```js
+dropProperties(
+  [{ id: 1, name: "jon", age: 19 }, { id: 2, name: "jane", age: 21 }],
+  "name",
+  "age"
+); // [ { id: 1 }, { id: 2 } ]
+```

--- a/tag_database
+++ b/tag_database
@@ -62,6 +62,7 @@ dig:object,recursion,intermediate
 digitize:math,array,beginner
 distance:math,beginner
 drop:array,beginner
+dropProperties:array,object
 dropRight:array,beginner
 dropRightWhile:array,function,intermediate
 dropWhile:array,function,intermediate

--- a/test/dropProperties/dropProperties.js
+++ b/test/dropProperties/dropProperties.js
@@ -1,0 +1,5 @@
+const dropProperties = (objArr, ...propKeys) => {
+  propKeys.map(propKey => objArr.forEach(obj => delete obj[propKey]));
+  return objArr;
+};
+module.exports = dropProperties;

--- a/test/dropProperties/dropProperties.test.js
+++ b/test/dropProperties/dropProperties.test.js
@@ -1,0 +1,32 @@
+const expect = require("expect");
+const dropProperties = require("./dropProperties.js");
+
+test("drop is a Function", () => {
+  expect(dropProperties).toBeInstanceOf(Function);
+});
+
+test("removes one property", () => {
+  expect(
+    dropProperties(
+      [
+        { id: 1, name: "jon", gender: "male" },
+        { id: 2, name: "jane", gender: "female" }
+      ],
+      "gender"
+    )[0].hasOwnProperty("gender")
+  ).toBeFalsy();
+});
+test("removes multiple properties", () => {
+  expect(
+    Object.keys(
+      dropProperties(
+        [
+          { id: 1, name: "jon", gender: "male", age: 19 },
+          { id: 2, name: "jane", gender: "female", age: 24 }
+        ],
+        "gender",
+        "age"
+      )[0]
+    ).length
+  ).toEqual(2);
+});


### PR DESCRIPTION

## Description
Adds new snippet (.md, tests, tag_database) that drops properties in an array of objects (i.e. response data). Note that I added manually test files and run them in a different (isolated) environment as the `tester` and `test` script of this repo throws me an error and exits (not yet resolved).

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
