### PR TITLE
[FIX] Updates typo in 'sample' snippet from 'of' to 'off'

### DIFF
--- a/snippets/sample.md
+++ b/snippets/sample.md
@@ -2,7 +2,7 @@
 
 Returns a random element from an array.
 
-Use `Math.random()` to generate a random number, multiply it by `length` and round it of to the nearest whole number using `Math.floor()`.
+Use `Math.random()` to generate a random number, multiply it by `length` and round it off to the nearest whole number using `Math.floor()`.
 This method also works with strings.
 
 ```js


### PR DESCRIPTION
## Description
Updates 'Sample' snippet description text from '...round it of to the nearest' to '...round it off to the nearest'. Chaning 'of' to 'off'.

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [x] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
