### PR TITLE
Add toTitleCase snippet and update tag_database accordingly

### DIFF
--- a/snippets/toTitleCase.md
+++ b/snippets/toTitleCase.md
@@ -1,0 +1,22 @@
+### toTitleCase
+
+Converts a string to title case.
+
+The algorithm featured here breaks down as follows:
+1. Break the string into words, using a [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
+2. Capitalize each of them
+3. Stich them back together, using the whitespace `' '` character as a separator
+
+```js
+const toTitleCase = str => str
+  .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
+  .map(x => x.charAt(0).toUpperCase() + x.slice(1).toLowerCase())
+  .join(' ');
+```
+
+```js
+toTitleCase('some_database_field_name'); // 'Some Database Field Name'
+toTitleCase('Some label that needs to be title-cased'); // 'Some Label That Needs To Be Title Cased'
+toTitleCase('some-package-name'); // 'Some Package Name'
+toTitleCase('some-mixed_string with spaces_underscores-and-hyphens'); // 'Some Mixed String With Spaces Underscores And Hyphens'
+```

--- a/snippets/toTitleCase.md
+++ b/snippets/toTitleCase.md
@@ -2,10 +2,7 @@
 
 Converts a string to title case.
 
-The algorithm featured here breaks down as follows:
-1. Break the string into words, using a [Regular Expression](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions)
-2. Capitalize each of them
-3. Stich them back together, using the whitespace `' '` character as a separator
+Break the string into words, using a regexp, and combine them capitalizing the first letter of each word and adding a whitespace between them.
 
 ```js
 const toTitleCase = str => str

--- a/snippets/toTitleCase.md
+++ b/snippets/toTitleCase.md
@@ -7,7 +7,7 @@ Break the string into words, using a regexp, and combine them capitalizing the f
 ```js
 const toTitleCase = str => str
   .match(/[A-Z]{2,}(?=[A-Z][a-z]+[0-9]*|\b)|[A-Z]?[a-z]+[0-9]*|[A-Z]|[0-9]+/g)
-  .map(x => x.charAt(0).toUpperCase() + x.slice(1).toLowerCase())
+  .map(x => x.charAt(0).toUpperCase() + x.slice(1))
   .join(' ');
 ```
 

--- a/tag_database
+++ b/tag_database
@@ -301,6 +301,7 @@ tomorrow:date,intermediate
 toOrdinalSuffix:utility,math,intermediate
 toSafeInteger:math,beginner
 toSnakeCase:string,regexp,intermediate
+toTitleCase:string,regepx,intermediate
 transform:object,array,intermediate
 triggerEvent:browser,event,intermediate
 truncateString:string,beginner


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description

I added a `toTitleCase` snippet to convert any string to its title-case equivalent.

It reuses the same "tokeniser" RegExp that is already featured in the `toCamelCase`, `toKebabCase` and `toSnakeCase` snippets.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
