### PR TITLE
add filterFalsy snippet, tags, and tests

### DIFF
--- a/snippets/filterFalsy.md
+++ b/snippets/filterFalsy.md
@@ -5,7 +5,7 @@ Filters out the falsy values in an array.
 Use `Array.prototype.filter()` to get an array containing only truthy values.
 
 ```js
-const filterFalsy = arr => arr.filter(Boolean)
+const filterFalsy = arr => arr.filter(Boolean);
 ```
 
 ```js

--- a/snippets/filterFalsy.md
+++ b/snippets/filterFalsy.md
@@ -1,0 +1,13 @@
+### filterFalsy
+
+Filters out the falsy values in an array.
+
+Use `Array.prototype.filter()` to get an array containing only truthy values.
+
+```js
+const filterFalsy = arr => arr.filter(Boolean)
+```
+
+```js
+filterFalsy(['', true, {}, false, 'sample', 1, 0]); // [true, {}, 'sample', 1]
+```

--- a/tag_database
+++ b/tag_database
@@ -75,6 +75,7 @@ everyNth:array,beginner
 extendHex:utility,string,intermediate
 factorial:math,recursion,beginner
 fibonacci:math,array,beginner
+filterFalsy:array,beginner
 filterNonUnique:array,beginner
 filterNonUniqueBy:array,function,intermediate
 findKey:object,function,intermediate

--- a/test/filterFalsy.test.js
+++ b/test/filterFalsy.test.js
@@ -1,5 +1,5 @@
 const expect = require('expect');
-const {filterFalsy} = require('._30s.js');
+const { filterFalsy } = require('./_30s.js');
 
 test('filterFalsy is a Function', () => {
   expect(filterFalsy).toBeInstanceOf(Function);

--- a/test/filterFalsy.test.js
+++ b/test/filterFalsy.test.js
@@ -1,0 +1,18 @@
+const expect = require('expect');
+const {filterFalsy} = require('._30s.js');
+
+test('filterFalsy is a Function', () => {
+  expect(filterFalsy).toBeInstanceOf(Function);
+});
+
+test('filterFalsy filters different types of falsy values', () => {
+  expect(filterFalsy(['', true, {}, false, 'sample', 1, 0])).toEqual([true, {}, 'sample', 1]);
+});
+
+test('filterFalsy returns an empty array if you pass it an array of falsy values', () => {
+  expect(filterFalsy(['', 0, false, '', false, 0])).toEqual([]);
+});
+
+test('filterFalsy returns all of the truthy elements in an array', () => {
+  expect(filterFalsy([true, null, 'test', {}, []])).toEqual([true, 'test', {}, []]);
+});


### PR DESCRIPTION
FEATURE filterFalsy snippet

## Description
Add filterFalsy snippet that filters falsy elements from an array.

**BREAKING CHANGES**
*THE TESTS DON'T PASS*

The tdd script ```npm run tester``` doesn't work. It fails because of tests. Some unrelated tests seem to fail.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
