### PR TITLE
[FEATURE] add isNegativeZero

### DIFF
--- a/snippets/isNegativeZero.md
+++ b/snippets/isNegativeZero.md
@@ -1,8 +1,8 @@
 ### isNegativeZero
 
-Checks if the given value is a negative zero `-0`.
+Checks if the given value is equal to negative zero (`-0`).
 
-Checks whether a passed value is equal to `0` and if one devided by the value equals `-Infinity`.
+Checks whether a passed value is equal to `0` and if `1` divided by the value equals `-Infinity`.
 
 ```js
 const isNegativeZero = val => val === 0 && 1 / val === -Infinity;

--- a/snippets/isNegativeZero.md
+++ b/snippets/isNegativeZero.md
@@ -1,0 +1,14 @@
+### isNegativeZero
+
+Checks if the given value is a negative zero `-0`.
+
+Checks whether a passed value is equal to `0` and if one devided by the value equals `-Infinity`.
+
+```js
+const isNegativeZero = val => val === 0 && 1 / val === -Infinity;
+```
+
+```js
+isNegativeZero(-0); // true
+isNegativeZero(0); // false
+```

--- a/tag_database
+++ b/tag_database
@@ -145,6 +145,7 @@ isEmpty:type,array,object,string,beginner
 isEven:math,beginner
 isFunction:type,function,beginner
 isLowerCase:string,utility,beginner
+isNegativeZero:math,utility,beginner
 isNil:type,beginner
 isNull:type,beginner
 isNumber:type,math,beginner

--- a/test/isNegativeZero.test.js
+++ b/test/isNegativeZero.test.js
@@ -1,0 +1,15 @@
+const expect = require('expect');
+const { isNegativeZero } = require('._30s.js');
+
+test('isNegativeZero is a Function', () => {
+  expect(isNegativeZero).toBeInstanceOf(Function);
+});
+test('0 is not a -0', () => {
+  expect(isNegativeZero(0)).toBeFalsy();
+});
+test('-0 is a negative zero', () => {
+  expect(isNegativeZero(-0)).toBeTruthy();
+});
+test('1 is not a negative zero', () => {
+  expect(isNegativeZero(1)).toBeFalsy();
+});


### PR DESCRIPTION
## Description

I've added a handy utility snippet that checks whether a provided value is negative zero or not. 

Before you make a noise, let me explain a bit how JavaScript handles numbers and why is this function useful to some people.

#### JavaScript 0 and -0 examples
```js
0 === -0 //  true
0 / 3 // equals to 0
0 / -3 // equals to  -0

Infinity === -Infinity // false
```
Yes. I know that negative zero doesn't exist in real Math but this is just how JavaScript engine threats it. Whenever JavaScript engine works with dividing negatives, it treats them as positives and adds `-` afterward.

#### Usage
Not much as you've guessed it but this function can be used when writing complex animations, a `-0` on just finished animation can provide information on whether the animation was coming from the right or the left side etc. 

#### Note about tests
I wrote the tests, they don't pass due to the way they work. In order to make them work the `_30s` needs `isNegativeZero` module in it. (I've tested manually and they do work). 

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
