### PR TITLE
[FEATURE] add normalizeVector snippet

### DIFF
--- a/snippets/normalizeVector.md
+++ b/snippets/normalizeVector.md
@@ -1,12 +1,12 @@
 ### normalizeVector
 
-Returns a list consisting of a 3-element array representing a vector that is the normalized version of another vector.
+Returns a 3-element array, representing a vector that is the normalized version of another vector.
 
 Use `Math.sqrt()` to calculate `magnitude`, divide components by `magnitude`.
 
 ```js
 const normalize = ([x, y, z]) => {
-  magnitude = Math.sqrt(x*x + y*y + z*z);
+  let magnitude = Math.sqrt(x*x + y*y + z*z);
   return [x/magnitude, y/magnitude, z/magnitude];
 }
 ```

--- a/snippets/normalizeVector.md
+++ b/snippets/normalizeVector.md
@@ -1,0 +1,18 @@
+### normalizeVector
+
+Returns a list consisting of a 3-element array representing a vector that
+is the normalized version of another vector.
+
+Use `Math.sqrt()` to calculate magnitude, divide components by magnitude.
+
+```js
+const normalize = ([x, y, z]) => {
+    magnitude = Math.sqrt(x*x + y*y + z*z)
+    return [x/magnitude, y/magnitude, z/magnitude]
+}
+```
+
+```js
+normalize([2, 2, 1]); // [0.8164965809277,0.4082482904638,0.4082482904638]
+normalize([10, 0, 0]); // [10, 0, 0]
+```

--- a/snippets/normalizeVector.md
+++ b/snippets/normalizeVector.md
@@ -1,14 +1,13 @@
 ### normalizeVector
 
-Returns a list consisting of a 3-element array representing a vector that
-is the normalized version of another vector.
+Returns a list consisting of a 3-element array representing a vector that is the normalized version of another vector.
 
-Use `Math.sqrt()` to calculate magnitude, divide components by magnitude.
+Use `Math.sqrt()` to calculate `magnitude`, divide components by `magnitude`.
 
 ```js
 const normalize = ([x, y, z]) => {
-    magnitude = Math.sqrt(x*x + y*y + z*z)
-    return [x/magnitude, y/magnitude, z/magnitude]
+  magnitude = Math.sqrt(x*x + y*y + z*z);
+  return [x/magnitude, y/magnitude, z/magnitude];
 }
 ```
 

--- a/tag_database
+++ b/tag_database
@@ -194,6 +194,7 @@ negate:function,beginner
 nest:object,intermediate
 nodeListToArray:browser,array,beginner
 none:array,function,beginner
+normalizeVector:beginner,vector
 nthArg:utility,function,beginner
 nthElement:array,beginner
 objectFromPairs:object,array,beginner

--- a/tag_database
+++ b/tag_database
@@ -194,7 +194,7 @@ negate:function,beginner
 nest:object,intermediate
 nodeListToArray:browser,array,beginner
 none:array,function,beginner
-normalizeVector:beginner,vector
+normalizeVector:math,vector,beginner
 nthArg:utility,function,beginner
 nthElement:array,beginner
 objectFromPairs:object,array,beginner


### PR DESCRIPTION
## Description
This PR adds a snippet that normalizes a vector. The normalization process takes a vector and returns a second vector with the same direction, but a magnitude of 1.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
