### PR TITLE
[FEATURE] chainAsync update: last function shouldn't get 'next' as argument

### DIFF
--- a/snippets/chainAsync.md
+++ b/snippets/chainAsync.md
@@ -10,7 +10,7 @@ const chainAsync = fns => {
   const last = fns[fns.length - 1];
   const next = () => {
     const fn = fns[curr++]
-    fn === last ? fn(undefined) : fn(next);
+    fn === last ? fn() : fn(next);
   }
   next();
 };

--- a/snippets/chainAsync.md
+++ b/snippets/chainAsync.md
@@ -6,10 +6,11 @@ Loop through an array of functions containing asynchronous events, calling `next
 
 ```js
 const chainAsync = fns => {
-  let curr = 0, last = fns[fns.length - 1];
+  let curr = 0;
+  const last = fns[fns.length - 1];
   const next = () => {
     const fn = fns[curr++]
-    fn(fn === last ? null : next)
+    fn === last ? fn(undefined) : fn(next);
   }
   next();
 };

--- a/snippets/chainAsync.md
+++ b/snippets/chainAsync.md
@@ -6,8 +6,11 @@ Loop through an array of functions containing asynchronous events, calling `next
 
 ```js
 const chainAsync = fns => {
-  let curr = 0;
-  const next = () => fns[curr++](next);
+  let curr = 0, last = fns[fns.length - 1];
+  const next = () => {
+    const fn = fns[curr++]
+    fn(fn === last ? null : next)
+  }
   next();
 };
 ```
@@ -20,6 +23,10 @@ chainAsync([
   },
   next => {
     console.log('1 second');
+    setTimeout(next, 1000);
+  },
+  () => {
+    console.log('2 second');
   }
 ]);
 ```

--- a/test/chainAsync.test.js
+++ b/test/chainAsync.test.js
@@ -28,7 +28,7 @@ test('Last function does not receive "next" argument', () => {
       next();
     },
     next => {
-      expect(next).toBe(null);
+      expect(next).toBe(undefined);
     }
   ]);
 });

--- a/test/chainAsync.test.js
+++ b/test/chainAsync.test.js
@@ -5,18 +5,30 @@ test('chainAsync is a Function', () => {
   expect(chainAsync).toBeInstanceOf(Function);
 });
 
+let incrementer = 0
 test('Calls all functions in an array', () => {
+  chainAsync([
+    next => {
+      incrementer += 1
+      next();
+    },
+    next => {
+      incrementer += 1
+      next();
+    },
+    next => {
+      expect(incrementer).toEqual(2);
+    }
+  ]);
+});
+
+test('Last function does not receive "next" argument', () => {
   chainAsync([
     next => {
       next();
     },
     next => {
-      (() => {
-        next();
-      })();
-    },
-    next => {
-      expect(true).toBeTruthy();
+      expect(next).toBe(null);
     }
   ]);
-});
+})

--- a/test/chainAsync.test.js
+++ b/test/chainAsync.test.js
@@ -5,15 +5,15 @@ test('chainAsync is a Function', () => {
   expect(chainAsync).toBeInstanceOf(Function);
 });
 
-let incrementer = 0
+let incrementer = 0;
 test('Calls all functions in an array', () => {
   chainAsync([
     next => {
-      incrementer += 1
+      incrementer += 1;
       next();
     },
     next => {
-      incrementer += 1
+      incrementer += 1;
       next();
     },
     next => {
@@ -31,4 +31,4 @@ test('Last function does not receive "next" argument', () => {
       expect(next).toBe(null);
     }
   ]);
-})
+});


### PR DESCRIPTION
## Description
chainAsync update: last function shouldn't get 'next' as argument. That way it's easier to add a condition within the functions to check whether they're the last one, e.g. `if(next){/* is last function*/}else{/* isn't */}`. This is useful when the array of functions is generated, rather than hard-coded.

My tests pass, but the `npm` scripts outlined in the docs didn't update `test/_30.js`. Not sure what additional step is needed for that.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
- [x] My PR doesn't include any `testlog` changes. 
