### PR TITLE
[ENHANCEMENT] Replace double-quote characters in CSV fields

### DIFF
--- a/snippets/arrayToCSV.md
+++ b/snippets/arrayToCSV.md
@@ -3,15 +3,17 @@
 Converts a 2D array to a comma-separated values (CSV) string.
 
 Use `Array.prototype.map()` and `Array.prototype.join(delimiter)` to combine individual 1D arrays (rows) into strings.
+Use `String.prototype.replace()` to replace double-quote characters with pairs of quotes.
 Use `Array.prototype.join('\n')` to combine all rows into a CSV string, separating each row with a newline.
 Omit the second argument, `delimiter`, to use a default delimiter of `,`.
 
 ```js
 const arrayToCSV = (arr, delimiter = ',') =>
-  arr.map(v => v.map(x => `"${x}"`).join(delimiter)).join('\n');
+  arr.map(row => row.map(val => `"${val.replace(/"/g, '""')}"`).join(delimiter)).join('\n');
 ```
 
 ```js
 arrayToCSV([['a', 'b'], ['c', 'd']]); // '"a","b"\n"c","d"'
 arrayToCSV([['a', 'b'], ['c', 'd']], ';'); // '"a";"b"\n"c";"d"'
+arrayToCSV([['a', 'b'], ['c', '"d"']]); // '"a","b"\n"c","""d"""'
 ```

--- a/snippets/arrayToCSV.md
+++ b/snippets/arrayToCSV.md
@@ -9,7 +9,8 @@ Omit the second argument, `delimiter`, to use a default delimiter of `,`.
 
 ```js
 const arrayToCSV = (arr, delimiter = ',') =>
-  arr.map(row => row.map(val => `"${val.replace(/"/g, '""')}"`).join(delimiter)).join('\n');
+  arr.map(row => row.map(val =>
+    `"${val.replace(/"/g, '""')}"`).join(delimiter)).join('\n');
 ```
 
 ```js

--- a/test/arrayToCSV.test.js
+++ b/test/arrayToCSV.test.js
@@ -10,3 +10,6 @@ test('arrayToCSV works with default delimiter', () => {
 test('arrayToCSV works with custom delimiter', () => {
   expect(arrayToCSV([['a', 'b'], ['c', 'd']], ';')).toBe('"a";"b"\n"c";"d"');
 });
+test('arrayToCSV replaces double quotes', () => {
+  expect(arrayToCSV([['a', 'b'], ['c', '"d"']])).toBe('"a","b"\n"c","""d"""');
+});


### PR DESCRIPTION
Hi everyone! :-)

## Description
As CSV fields are wrapped in double quotes by default, double-quote characters should also be replaced with pairs of quotes which is more or less the standard way to handle these. I was also thinking about an optional escape character argument, but didn't want to over-engineer it at this point.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
