### PR TITLE
[FIX] Fix title overlaping after hash link redirect (#745)

### DIFF
--- a/docs/scss/style.scss
+++ b/docs/scss/style.scss
@@ -522,6 +522,11 @@ h2.category-name {
     .section.card-content{
       background: var(#{$back-color-var});
       padding: calc(1.5 * var(#{$universal-padding-var}));
+      .anchor{
+        position: absolute;
+        left: 0px;
+        top: -56px; // trick for hash link, should be same as header height
+      }
     }
     .collapse {
       display: block;

--- a/scripts/web.js
+++ b/scripts/web.js
@@ -57,7 +57,7 @@ ${
 }
   ${md
     .render(`\n${addCornerTag ? snippetList[snippetKey[0] + '.md'] : snippetList[snippetKey[0]]}`)
-    .replace(/<h3/g, `<div class="section card-content"><h4 id="${snippetKey[0].toLowerCase()}"`)
+    .replace(/<h3/g, `<div class="section card-content"><div class="anchor" id="${snippetKey[0].toLowerCase()}"></div><h4`)
     .replace(/<\/h3>/g, '</h4>')
     .replace(
       /<pre><code class="language-js">/m,
@@ -369,7 +369,7 @@ try {
       '<div class="card code-card"><div class="section card-content">' +
       md
         .render(`\n${filteredGlossarySnippets[snippet[0]]}`)
-        .replace(/<h3/g, `<h4 id="${snippet[0].toLowerCase()}"`)
+        .replace(/<h3/g, `<div class="anchor" id="${snippet[0].toLowerCase()}"></div> <h4`)
         .replace(/<\/h3>/g, '</h4>') +
       '</div></div>';
   }


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
Resolves #745. Small css trick for fix hash link overlaping bug. Website files should be rebuilden.

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
-  [x] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
