### PR TITLE
[FIX] #907 Explain next tick logic on `hashNode`

### DIFF
--- a/snippets/hashNode.md
+++ b/snippets/hashNode.md
@@ -2,7 +2,7 @@
 
 Creates a hash for a value using the [SHA-256](https://en.wikipedia.org/wiki/SHA-2) algorithm. Returns a promise.
 
-Use `crypto` API to create a hash for the given value.
+Use `crypto` API to create a hash for the given value, `setTimeout` to prevent blocking on a long operation, and a `Promise` to give it a familiar interface.
 
 ```js
 const crypto = require('crypto');


### PR DESCRIPTION
It was something we forgot and that we don't want to forget. Sending it onto the event loop prevents us from blocking with a long operation, allowing other things on the event loop to happen before a take a possibly long time

Resolves #907 

<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
We push the hashing onto the next tick and use a promise because the hash could take a long time to complete.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
