### PR TITLE
FLIP the behavior of takeWhile

### DIFF
--- a/snippets/takeWhile.md
+++ b/snippets/takeWhile.md
@@ -1,17 +1,17 @@
 ### takeWhile
 
-Removes elements in an array until the passed function returns `true`. Returns the removed elements.
+returns the first elements in an array where the passed function returns `true`. 
 
-Loop through the array, using a `for...of` loop over `Array.prototype.entries()` until the returned value from the function is `true`.
-Return the removed elements, using `Array.prototype.slice()`.
+Loop through the array, using a `for...of` loop over `Array.prototype.entries()` until the returned value from the function is `false`.
+Return the took elements, using `Array.prototype.slice()`.
 
 ```js
 const takeWhile = (arr, func) => {
-  for (const [i, val] of arr.entries()) if (func(val)) return arr.slice(0, i);
+  for (const [i, val] of arr.entries()) if (!func(val)) return arr.slice(0, i);
   return arr;
 };
 ```
 
 ```js
-takeWhile([1, 2, 3, 4], n => n >= 3); // [1, 2]
+takeWhile([1, 2, 3, 4], n => n <= 3); // [1, 2, 3]
 ```

--- a/test/takeWhile.test.js
+++ b/test/takeWhile.test.js
@@ -4,9 +4,9 @@ const {takeWhile} = require('./_30s.js');
 test('takeWhile is a Function', () => {
   expect(takeWhile).toBeInstanceOf(Function);
 });
-test('Removes elements until the function returns true', () => {
-  expect(takeWhile([1, 2, 3, 4], n => n >= 3)).toEqual([1, 2]);
+test('Returns the first elements where the function returns true', () => {
+  expect(takeWhile([1, 2, 3, 4], n => n <= 3)).toEqual([1, 2, 3]);
 });
-test('Removes elements until the function returns true', () => {
-  expect(takeWhile([1, 2, 3, 4], n => false)).toEqual([1, 2, 3, 4]);
+test('Returns the first elements where the function returns true', () => {
+  expect(takeWhile([1, 2, 3, 4], n => true)).toEqual([1, 2, 3, 4]);
 });


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
I think that `takeWhile` should gather elements while the `predicate` returns `true` and not the inverse

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)

## Guidelines
- [ ] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
