### PR TITLE
[FIX] Minor typo fix

### DIFF
--- a/snippets/minBy.md
+++ b/snippets/minBy.md
@@ -2,7 +2,7 @@
 
 Returns the minimum value of an array, after mapping each element to a value using the provided function.
 
-Use `Array.prototype.map()` to map each element to the value returned by `fn`, `Math.min()` to get the maximum value.
+Use `Array.prototype.map()` to map each element to the value returned by `fn`, `Math.min()` to get the minimum value.
 
 ```js
 const minBy = (arr, fn) => Math.min(...arr.map(typeof fn === 'function' ? fn : val => val[fn]));


### PR DESCRIPTION
## Description
Fixed a minor typo in `minBy` description that says "maximum" instead of "minimum"

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [x] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
