### PR TITLE
[FIX] #935 isNumber is wrong for NaN

### DIFF
--- a/snippets/isNumber.md
+++ b/snippets/isNumber.md
@@ -2,7 +2,8 @@
 
 Checks if the given argument is a number.
 
-Use `typeof` to check if a value is classified as a number primitive. Because `typeof NaN` is equal to `number`, the `val === val` is for protection. NaN compares unequal (via ==, !=, ===, and !==) to any other value, including to another NaN value.
+Use `typeof` to check if a value is classified as a number primitive. 
+To safeguard against `NaN`, check if `val === val` (as `NaN` has a `typeof` equal to `number` and is the only value not equal to itself).
 
 ```js
 const isNumber = val => typeof val === 'number' && val === val;

--- a/snippets/isNumber.md
+++ b/snippets/isNumber.md
@@ -2,13 +2,14 @@
 
 Checks if the given argument is a number.
 
-Use `typeof` to check if a value is classified as a number primitive.
+Use `typeof` to check if a value is classified as a number primitive. Because `typeof NaN` is equal to `number`, the `val === val` is for protection. NaN compares unequal (via ==, !=, ===, and !==) to any other value, including to another NaN value.
 
 ```js
-const isNumber = val => typeof val === 'number';
+const isNumber = val => typeof val === 'number' && val === val;
 ```
 
 ```js
-isNumber('1'); // false
 isNumber(1); // true
+isNumber('1'); // false
+isNumber(NaN); // false
 ```

--- a/test/isNumber.test.js
+++ b/test/isNumber.test.js
@@ -10,3 +10,6 @@ test('passed argument is a number', () => {
 test('passed argument is not a number', () => {
   expect(isNumber('1')).toBeFalsy();
 });
+test('passed argument is not a number', () => {
+  expect(isNumber(NaN)).toBeFalsy();
+});


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
Resolves #935 

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
