### PR TITLE
[FEATURE] add checkProp utility function for inspecting objects

### DIFF
--- a/snippets/checkProp.md
+++ b/snippets/checkProp.md
@@ -1,0 +1,29 @@
+### checkProp
+
+Given a `predicate` function and a `prop` string this curried function will then take an `object` to inspect by calling the property and passing it to the predicate.
+
+It summons `prop` on `obj` and passes it to a provided `predicate` function and returns a masked boolean
+
+```js
+const checkProp = (predicate, prop) => obj => !!predicate(obj[prop])
+```
+
+```js
+const lengthIs4 = checkProp(l => l === 4, 'length')
+lengthIs4([]) // false
+lengthIs4([1,2,3,4]) // true
+lengthIs4(new Set([1,2,3,4]) // false (Set uses Size, not length)
+
+const session = { user: {} }
+const validUserSession = checkProps(u => u.active && !u.disabled, 'user')
+
+validUserSession(session) // false
+
+session.user.active = true
+validUserSession(session) // true
+
+const noLength(l => l === undefined, 'length')
+noLength([]) // false
+noLength({}) // true
+noLength(new Set()) // true
+```

--- a/snippets/checkProp.md
+++ b/snippets/checkProp.md
@@ -12,7 +12,7 @@ const checkProp = (predicate, prop) => obj => !!predicate(obj[prop])
 const lengthIs4 = checkProp(l => l === 4, 'length')
 lengthIs4([]) // false
 lengthIs4([1,2,3,4]) // true
-lengthIs4(new Set([1,2,3,4]) // false (Set uses Size, not length)
+lengthIs4(new Set([1,2,3,4])) // false (Set uses Size, not length)
 
 const session = { user: {} }
 const validUserSession = checkProps(u => u.active && !u.disabled, 'user')

--- a/tag_database
+++ b/tag_database
@@ -23,6 +23,7 @@ capitalize:string,array,intermediate
 capitalizeEveryWord:string,regexp,intermediate
 castArray:utility,array,type,beginner
 chainAsync:function,intermediate
+checkProp:function,object,utility,beginner
 chunk:array,intermediate
 clampNumber:math,beginner
 cloneRegExp:utility,regexp,intermediate


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
Adds a simple utility function that allows for easy creation of predicate functions that inspect passed objects without passing the context to the predicate, allowing for simpler predicate functions, and easier composition.
## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
