### PR TITLE
[ENHANCEMENT] arrayToCSV escape quotes in strings and un-quote numeric vals

### DIFF
--- a/snippets/arrayToCSV.md
+++ b/snippets/arrayToCSV.md
@@ -8,10 +8,11 @@ Omit the second argument, `delimiter`, to use a default delimiter of `,`.
 
 ```js
 const arrayToCSV = (arr, delimiter = ',') =>
-  arr.map(v => v.map(x => `"${x}"`).join(delimiter)).join('\n');
+  arr.map(v => v.map(x => isNaN(x) ? `"${x.replace(/"/g, '""')}"` : x ).join(delimiter)).join('\n');
 ```
 
 ```js
 arrayToCSV([['a', 'b'], ['c', 'd']]); // '"a","b"\n"c","d"'
 arrayToCSV([['a', 'b'], ['c', 'd']], ';'); // '"a";"b"\n"c";"d"'
+arrayToCSV([['a', '"b" great'], ['c', 3.1415]]); // '"a","""b"" great"\n"c",3.1415'
 ```

--- a/test/arrayToCSV.test.js
+++ b/test/arrayToCSV.test.js
@@ -10,3 +10,6 @@ test('arrayToCSV works with default delimiter', () => {
 test('arrayToCSV works with custom delimiter', () => {
   expect(arrayToCSV([['a', 'b'], ['c', 'd']], ';')).toBe('"a";"b"\n"c";"d"');
 });
+test('arrayToCSV escapes quotes and doesn\'t quote numbers', () => {
+  expect(arrayToCSV([['a', '"b" great'], ['c', 3.1415]])).toBe('"a","""b"" great"\n"c",3.1415');
+});


### PR DESCRIPTION
## Description
Most CSV parsers understand strings to be wrapped in double quotes, and double-quotes within strings to be escaped with additional double quotes. In addition, values not enclosed in quotes should be interpreted as numeric.
This modifies the existing one-liner to provide this functionality. The function should now produce a CSV that can be parsed by any compliant reader for just about any kind of input.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
