### PR TITLE
[FIX] Use mapFn belong to Array.from,  instead of Array.prototype.map

### DIFF
--- a/snippets/initialize2DArray.md
+++ b/snippets/initialize2DArray.md
@@ -2,11 +2,10 @@
 
 Initializes a 2D array of given width and height and value.
 
-Use `Array.prototype.map()` to generate h rows where each is a new array of size w initialize with value. If the value is not provided, default to `null`.
+Use `Array.from()` to generate h rows where each is a new array of size w initialize with value. If the value is not provided, default to `null`.
 
 ```js
-const initialize2DArray = (w, h, val = null) =>
-  Array.from({ length: h }).map(() => Array.from({ length: w }).fill(val));
+const initialize2DArray = (w, h, val = null) => Array.from(Array(h), () => Array(w).fill(val));
 ```
 
 ```js

--- a/snippets/initializeNDArray.md
+++ b/snippets/initializeNDArray.md
@@ -9,7 +9,9 @@ Use `Array.prototype.map()` to generate rows where each is a new array initializ
 const initializeNDArray = (val, ...args) =>
   args.length === 0
     ? val
-    : Array.from({ length: args[0] }).map(() => initializeNDArray(val, ...args.slice(1)));
+    : Array.from(Array(args[0]), () =>
+        initializeNDArray(val, ...args.slice(1))
+      );
 ```
 
 ```js


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
Change `Array.from(...).map(Fn)` to `Array.from(...,Fn)`.
`Array.from` has own `mapFn` param. I think it is better.

<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
