### PR TITLE
Maps and Sets are not collections, but Stores

### DIFF
--- a/snippets/isEmpty.md
+++ b/snippets/isEmpty.md
@@ -9,8 +9,6 @@ const isEmpty = val => val == null || !(Object.keys(val) || val).length;
 ```
 
 ```js
-isEmpty(new Map()); // true
-isEmpty(new Set()); // true
 isEmpty([]); // true
 isEmpty({}); // true
 isEmpty(''); // true

--- a/snippets/isEmpty.md
+++ b/snippets/isEmpty.md
@@ -1,6 +1,6 @@
 ### isEmpty
 
-Returns true if the a value is an empty object, collection, map or set, has no enumerable properties or is any type that is not considered a collection.
+Returns true if the a value is an empty object, collection, has no enumerable properties or is any type that is not considered a collection.
 
 Check if the provided value is `null` or if its `length` is equal to `0`.
 


### PR DESCRIPTION
They use size instead of length

<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
Remove some confusing and incorrect langauge

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
