### PR TITLE
Minor typo fixes with drop and dropRight snippets

### DIFF
--- a/snippets/drop.md
+++ b/snippets/drop.md
@@ -2,7 +2,7 @@
 
 Returns a new array with `n` elements removed from the left.
 
-Use `Array.prototype.slice()` to slice the remove the specified number of elements from the left.
+Use `Array.prototype.slice()` to remove the specified number of elements from the left.
 
 ```js
 const drop = (arr, n = 1) => arr.slice(n);

--- a/snippets/dropRight.md
+++ b/snippets/dropRight.md
@@ -2,7 +2,7 @@
 
 Returns a new array with `n` elements removed from the right.
 
-Use `Array.prototype.slice()` to slice the remove the specified number of elements from the right.
+Use `Array.prototype.slice()` to remove the specified number of elements from the right.
 
 ```js
 const dropRight = (arr, n = 1) => arr.slice(0, -n);


### PR DESCRIPTION
## Description
Fixing minor typos in the description from the drop and dropRight snippets. Fixed the use of slice and removed terms. 

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [x] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
