### PR TITLE
Update string.md as String literals aren't Strings

### DIFF
--- a/glossary/String.md
+++ b/glossary/String.md
@@ -2,3 +2,10 @@
 
 Strings are one of the primitive data types in JavaScript.
 They are sequences of characters and are used to represent text.
+They are copied into instances of the `String` class when needed automatically.
+
+```js
+var a = 'a'
+a.concat === String.prototype.concat // true
+a instanceof String // false
+```


### PR DESCRIPTION
String literals get copied into String instances when needed automatically.

This could probably be in a completely different file instead with an example of each type of literal being coerced into an instance

<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [ ] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
