### PR TITLE
Move devDependencies under dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,4 @@
 {
-  "devDependencies": {
-    "@babel/core": "^7.1.2",
-    "@babel/preset-env": "^7.1.0",
-    "chalk": "^2.4.1",
-    "codacy-coverage": "^3.2.0",
-    "eslint": "^5.7.0",
-    "fs-extra": "^6.0.0",
-    "html-minifier": "^3.5.20",
-    "jest": "^23.6.0",
-    "markdown-builder": "^0.8.4",
-    "markdown-it": "^8.4.2",
-    "node-sass": "^4.9.3",
-    "octicons": "^7.4.0",
-    "prettier": "^1.14.2",
-    "prismjs": "^1.15.0",
-    "rollup": "^0.58.2",
-    "rollup-plugin-babel": "^4.0.3",
-    "rollup-plugin-babel-minify": "^4.0.0"
-  },
   "name": "30-seconds-of-code",
   "description": "A collection of useful JavaScript snippets.",
   "version": "1.2.3",
@@ -53,5 +34,24 @@
     "url": "https://github.com/30-seconds/30-seconds-of-code/issues"
   },
   "homepage": "https://30secondsofcode.org/",
-  "dependencies": {}
+  "dependencies": {},
+  "devDependencies": {
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "chalk": "^2.4.1",
+    "codacy-coverage": "^3.2.0",
+    "eslint": "^5.7.0",
+    "fs-extra": "^6.0.0",
+    "html-minifier": "^3.5.20",
+    "jest": "^23.6.0",
+    "markdown-builder": "^0.8.4",
+    "markdown-it": "^8.4.2",
+    "node-sass": "^4.9.3",
+    "octicons": "^7.4.0",
+    "prettier": "^1.14.2",
+    "prismjs": "^1.15.0",
+    "rollup": "^0.58.2",
+    "rollup-plugin-babel": "^4.0.3",
+    "rollup-plugin-babel-minify": "^4.0.0"
+  }
 }


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
The `devDependencies` should not be at the top where we normally find the meta data like `name`, `version` and so on.

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [x] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
