### PR TITLE
[ENHANCEMENT] Simplify min and max date functions

### DIFF
--- a/snippets/maxDate.md
+++ b/snippets/maxDate.md
@@ -2,10 +2,10 @@
 
 Returns the maximum of the given dates.
 
-Use `Math.max.apply()` to find the maximum date value, `new Date()` to convert it to a `Date` object.
+Use the ES6 spread syntax with `Math.max` to find the maximum date value, `new Date()` to convert it to a `Date` object.
 
 ```js
-const maxDate = (...dates) => new Date(Math.max.apply(null, ...dates));
+const maxDate = dates => new Date(Math.max(...dates));
 ```
 
 ```js

--- a/snippets/minDate.md
+++ b/snippets/minDate.md
@@ -2,10 +2,10 @@
 
 Returns the minimum of the given dates.
 
-Use `Math.min.apply()` to find the minimum date value, `new Date()` to convert it to a `Date` object.
+Use the ES6 spread syntax to find the minimum date value, `new Date()` to convert it to a `Date` object.
 
 ```js
-const minDate = (...dates) => new Date(Math.min.apply(null, ...dates));
+const minDate = dates => new Date(Math.min(...dates));
 ```
 
 ```js

--- a/test/minDate.test.js
+++ b/test/minDate.test.js
@@ -4,7 +4,7 @@ const {minDate} = require('./_30s.js');
 test('minDate is a Function', () => {
   expect(minDate).toBeInstanceOf(Function);
 });
-test('minDate produces the maximum date', () => {
+test('minDate produces the minimum date', () => {
   const array = [
     new Date(2017, 4, 13),
     new Date(2018, 2, 12),


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
The functions already expect an array. There is no need to spread the argument and re-spread to use `apply`. This creates an unnecessary one-element array for no benefit. We could expect an array argument without spreading and then pass it directly to `apply`. But since we all encourage modern JS, using the spread syntax is better.

Resolves #984 
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.