### PR TITLE
[FIX] Fixed the Error For Negative Result

### DIFF
--- a/snippets/findLastIndex.md
+++ b/snippets/findLastIndex.md
@@ -2,15 +2,10 @@
 
 Returns the index of the last element for which the provided function returns a truthy value.
 
-Use `Array.prototype.map()` to map each element to an array with its index and value.
-Use `Array.prototype.filter()` to remove elements for which `fn` returns falsey values, `Array.prototype.pop()` to get the last one.
+Use `Array.prototype.reverse()` to reverse `arr` and then  `Array.prototype.findIndex()` to get the index of the reversed array for which `fn` returns a truthy value.  The bitwise not `~` of the index is then taken and if the result is zero the or `||` operator will instead return the bitwise not of the length of the array.  Finally, the above result is added to the length of the array to get the last index of the desired element for the orignal array or -1 if the function did not return a truthy value for any of its elements.
 
 ```js
-const findLastIndex = (arr, fn) =>
-  arr
-    .map((val, i) => [i, val])
-    .filter(([i, val]) => fn(val, i, arr))
-    .pop()[0];
+const findLastIndex = (arr, fn) => arr.length + (~arr.reverse().findIndex(fn) || ~arr.length);
 ```
 
 ```js


### PR DESCRIPTION
The function now returns -1 instead of an error as is expected when the passed function returns no truthy results for the passed array.  The function is also more elegant and far more performant for large arrays.

<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
