### PR TITLE
FIX(snippet): Changing instances of the word falsey to falsy

### DIFF
--- a/snippets/compact.md
+++ b/snippets/compact.md
@@ -1,8 +1,8 @@
 ### compact
 
-Removes falsey values from an array.
+Removes falsy values from an array.
 
-Use `Array.prototype.filter()` to filter out falsey values (`false`, `null`, `0`, `""`, `undefined`, and `NaN`).
+Use `Array.prototype.filter()` to filter out falsy values (`false`, `null`, `0`, `""`, `undefined`, and `NaN`).
 
 ```js
 const compact = arr => arr.filter(Boolean);

--- a/snippets/findLast.md
+++ b/snippets/findLast.md
@@ -2,7 +2,7 @@
 
 Returns the last element for which the provided function returns a truthy value.
 
-Use `Array.prototype.filter()` to remove elements for which `fn` returns falsey values, `Array.prototype.pop()` to get the last one.
+Use `Array.prototype.filter()` to remove elements for which `fn` returns falsy values, `Array.prototype.pop()` to get the last one.
 
 ```js
 const findLast = (arr, fn) => arr.filter(fn).pop();

--- a/snippets/findLastIndex.md
+++ b/snippets/findLastIndex.md
@@ -3,7 +3,7 @@
 Returns the index of the last element for which the provided function returns a truthy value.
 
 Use `Array.prototype.map()` to map each element to an array with its index and value.
-Use `Array.prototype.filter()` to remove elements for which `fn` returns falsey values, `Array.prototype.pop()` to get the last one.
+Use `Array.prototype.filter()` to remove elements for which `fn` returns falsy values, `Array.prototype.pop()` to get the last one.
 
 ```js
 const findLastIndex = (arr, fn) =>

--- a/snippets/omitBy.md
+++ b/snippets/omitBy.md
@@ -1,6 +1,6 @@
 ### omitBy
 
-Creates an object composed of the properties the given function returns falsey for. The function is invoked with two arguments: (value, key).
+Creates an object composed of the properties the given function returns falsy for. The function is invoked with two arguments: (value, key).
 
 Use `Object.keys(obj)` and `Array.prototype.filter()`to remove the keys for which `fn` returns a truthy value.
 Use `Array.prototype.reduce()` to convert the filtered keys back to an object with the corresponding key-value pairs.

--- a/snippets/pickBy.md
+++ b/snippets/pickBy.md
@@ -2,7 +2,7 @@
 
 Creates an object composed of the properties the given function returns truthy for. The function is invoked with two arguments: (value, key).
 
-Use `Object.keys(obj)` and `Array.prototype.filter()`to remove the keys for which `fn` returns a falsey value.
+Use `Object.keys(obj)` and `Array.prototype.filter()`to remove the keys for which `fn` returns a falsy value.
 Use `Array.prototype.reduce()` to convert the filtered keys back to an object with the corresponding key-value pairs.
 
 ```js

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -3,7 +3,7 @@ const {all} = require('./_30s.js');
 test('all is a Function', () => {
   expect(all).toBeInstanceOf(Function);
 });
-test('Returns true for arrays with no falsey values', () => {
+test('Returns true for arrays with no falsy values', () => {
   expect(all([4, 1, 2, 3])).toBeTruthy();
 });
 test('Returns false for arrays with 0', () => {

--- a/test/compact.test.js
+++ b/test/compact.test.js
@@ -3,7 +3,7 @@ const {compact} = require('./_30s.js');
 test('compact is a Function', () => {
   expect(compact).toBeInstanceOf(Function);
 });
-test('Removes falsey values from an array', () => {
+test('Removes falsy values from an array', () => {
   expect(compact([0, 1, false, 2, '', 3, 'a', 'e' * 23, NaN, 's', 34, null, undefined])).toEqual([
     1,
     2,

--- a/test/dig.test.js
+++ b/test/dig.test.js
@@ -18,7 +18,7 @@ test('Dig target success', () => {
   expect(dig(data, 'level3')).toEqual('some data');
 });
 
-test('Dig target with falsey value', () => {
+test('Dig target with falsy value', () => {
   expect(dig(data, 'level3f')).toEqual(false);
 });
 

--- a/test/omitBy.test.js
+++ b/test/omitBy.test.js
@@ -3,6 +3,6 @@ const {omitBy} = require('./_30s.js');
 test('omitBy is a Function', () => {
   expect(omitBy).toBeInstanceOf(Function);
 });
-test('Creates an object composed of the properties the given function returns falsey for', () => {
+test('Creates an object composed of the properties the given function returns falsy for', () => {
   expect(omitBy({ a: 1, b: '2', c: 3 }, x => typeof x === 'number')).toEqual({ b: '2' });
 });


### PR DESCRIPTION

## Description

Previously, the word falsy is spelled sometimes as falsy, and sometimes as falsey (with an e). This pull request brings consistency by changing them all to falsy, as the array's FilterFalsy function is spelled without an e.

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
