### PR TITLE
Simplify the comparison for a weekend

### DIFF
--- a/snippets/isWeekend.md
+++ b/snippets/isWeekend.md
@@ -3,11 +3,11 @@
 Results in a boolean representation of a specific date.
 
 Pass the specific date object firstly.
-Use `Date.getDay()` to check weekend then return a boolean.
+Use `Date.getDay()` to check weekend based on the day being returned as 0 - 6 using a modulo operation then return a boolean.
 
 ```js
 const isWeekend = (t = new Date()) => {
-  return t.getDay() === 0 || t.getDay() === 6;
+  return t.getDay() % 6 === 0;
 };
 ```
 


### PR DESCRIPTION
Since a weekend is either `0` or `6` from `Date#getDay()`, using `X % 6 === 0` will return the right Boolean value and lead to less function calls or comparisons.

Requires no changes to any tests as it still returns a boolean

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)

## Guidelines
- [X] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
