### PR TITLE
fix findLastIndex: return default index when not found

### DIFF
--- a/snippets/findLastIndex.md
+++ b/snippets/findLastIndex.md
@@ -4,15 +4,17 @@ Returns the index of the last element for which the provided function returns a 
 
 Use `Array.prototype.map()` to map each element to an array with its index and value.
 Use `Array.prototype.filter()` to remove elements for which `fn` returns falsy values, `Array.prototype.pop()` to get the last one.
+`-1` is the default value when not found.
 
 ```js
 const findLastIndex = (arr, fn) =>
-  arr
+  (arr
     .map((val, i) => [i, val])
     .filter(([i, val]) => fn(val, i, arr))
-    .pop()[0];
+    .pop() || [-1])[0];
 ```
 
 ```js
 findLastIndex([1, 2, 3, 4], n => n % 2 === 1); // 2 (index of the value 3)
+findLastIndex([1, 2, 3, 4], n => n === 5); // -1 (default value when not found)
 ```

--- a/test/_30s.js
+++ b/test/_30s.js
@@ -364,10 +364,10 @@ const filterNonUniqueBy = (arr, fn) =>
 const findKey = (obj, fn) => Object.keys(obj).find(key => fn(obj[key], key, obj));
 const findLast = (arr, fn) => arr.filter(fn).pop();
 const findLastIndex = (arr, fn) =>
-  arr
+  (arr
     .map((val, i) => [i, val])
     .filter(([i, val]) => fn(val, i, arr))
-    .pop()[0];
+    .pop() || [-1])[0];
 const findLastKey = (obj, fn) =>
   Object.keys(obj)
     .reverse()

--- a/test/findLastIndex.test.js
+++ b/test/findLastIndex.test.js
@@ -6,3 +6,6 @@ test('findLastIndex is a Function', () => {
 test('Finds last index for which the given function returns true', () => {
   expect(findLastIndex([1, 2, 3, 4], n => n % 2 === 1)).toBe(2);
 });
+test('Return default index when not found', () => {
+  expect(findLastIndex([1, 2, 3, 4], n => n === 5)).toBe(-1);
+});


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Scripts & Website & Meta (anything related to files in the [scripts folder](https://github.com/30-seconds/30-seconds-of-code/tree/master/scripts), how the repository's automated procedures work and the website)
- [ ] Glossary & Secondary Features (anything related to the glossary, such as new or updated terms or other secondary features)
- [ ] General, Typos, Misc. & Meta (everything else, typos, general stuff and meta files in the repository - e.g. the issue template)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
