### PR TITLE
[ENHANCEMENT] Make the example for unary clearer

### DIFF
--- a/snippets/ary.md
+++ b/snippets/ary.md
@@ -13,5 +13,5 @@ const ary = (fn, n) => (...args) => fn(...args.slice(0, n));
 
 ```js
 const firstTwoMax = ary(Math.max, 2);
-[[2, 6, 'a'], [8, 4, 6], [10]].map(x => firstTwoMax(...x)); // [6, 8, 10]
+[[2, 6, 'a'], [6, 4, 8], [10]].map(x => firstTwoMax(...x)); // [6, 6, 10]
 ```

--- a/test/ary.test.js
+++ b/test/ary.test.js
@@ -5,5 +5,5 @@ test('ary is a Function', () => {
 });
 const firstTwoMax = ary(Math.max, 2);
 test('Discards arguments with index >=n', () => {
-  expect([[2, 6, 'a'], [8, 4, 6], [10]].map(x => firstTwoMax(...x))).toEqual([6, 8, 10]);
+  expect([[2, 6, 'a'], [6, 4, 8], [10]].map(x => firstTwoMax(...x))).toEqual([6, 6, 10]);
 });


### PR DESCRIPTION
# [ENHANCEMENT] Make the example for unary clearer
## Description
Modify firstTwoMax()'s input array [8, 4, 6] to [6, 4, 8] to make it clear that firstTwoMax only cares about the first 2 arguments.


## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
