### PR TITLE
Create custom 'Snippet' schema in GraphQL

### DIFF
--- a/config.js
+++ b/config.js
@@ -21,4 +21,9 @@ module.exports = {
   moduleName: `_30s`,
   rollupInputFile: `imports.temp.js`,
   testModuleFile: `test/_30s.js`,
+  // Requirable JSONs
+  requirables: [
+    `snippets.json`,
+    `archivedSnippets.json`
+  ]
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -225,7 +225,6 @@ exports.createPages = ({ graphql, actions }) => {
           tags: node.tags.all,
           id: node.slug.slice(1)
         }));
-      const tagRegex = `/^\\s*${tag}/`;
       createPage({
         path: tagPath,
         component: tagPage,
@@ -236,12 +235,22 @@ exports.createPages = ({ graphql, actions }) => {
       });
     });
 
+    const beginnerSnippets = snippets
+      .filter(({ node }) => node.tags.all.includes('beginner'))
+      .filter(snippet => !snippet.node.archived)
+      .map(({ node }) => ({
+        title: node.title,
+        html: node.html.text,
+        tags: node.tags.all,
+        id: node.slug.slice(1)
+      }));
+
     createPage({
       path: `/beginner`,
       component: tagPage,
       context: {
         tag: `beginner snippets`,
-        tagRegex: `/beginner/`,
+        snippets: beginnerSnippets
       },
     });
 

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -188,7 +188,7 @@ exports.createPages = ({ graphql, actions }) => {
     const snippets = result.data.allSnippet.edges;
 
     snippets.forEach(snippet => {
-      if(!snippet.archived) {
+      if (!snippet.node.archived) {
         createPage({
           path: `/snippet${snippet.node.slug}`,
           component: snippetPage,
@@ -210,7 +210,11 @@ exports.createPages = ({ graphql, actions }) => {
     });
 
     // Create tag pages.
-    const tags = [...new Set(snippets.map(snippet => snippet.tags.primary))].sort((a,b) => a.localeCompare(b));
+    const tags = [...new Set(
+      snippets.map(snippet => (snippet.tags || {primary: null}).primary)
+    )]
+      .filter(Boolean)
+      .sort((a, b) => a.localeCompare(b));
 
     tags.forEach(tag => {
       const tagPath = `/tag/${toKebabCase(tag)}/`;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -127,10 +127,13 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest, getNodesByT
   const typeDefs = `
     type Snippet implements Node {
       html: HtmlData
-      tags: [String]
+      tags: TagData
       title: String
-      code: String
+      code: CodeData
       id: String
+      slug: String
+      path: String
+      text: TextData
     }
 
     type HtmlData @infer {
@@ -138,6 +141,21 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest, getNodesByT
       text: String
       code: String
       example: String
+    }
+
+    type CodeData @infer {
+      src: String
+      example: String
+    }
+
+    type TextData @infer {
+      full: String
+      short: String
+    }
+
+    type TagData @infer {
+      primary: String
+      all: [String]
     }
   `;
   createTypes(typeDefs);
@@ -161,9 +179,21 @@ exports.sourceNodes = ({ actions, createNodeId, createContentDigest, getNodesByT
     let mNode = markdownNodes.find(mN => mN.frontmatter.title === id);
     let nodeContent = {
       id,
-      tags: sNode.attributes.tags,
+      tags: {
+        all: sNode.attributes.tags,
+        primary: sNode.attributes.tags[0]
+      },
       title: mNode.frontmatter.title,
-      code: sNode.attributes.codeBlocks.es6
+      code: {
+        src: sNode.attributes.codeBlocks.es6,
+        example: sNode.attributes.codeBlocks.example
+      },
+      slug: mNode.fields.slug,
+      path: mNode.fileAbsolutePath,
+      text: {
+        full: sNode.attributes.text,
+        short: sNode.attributes.text.slice(0, sNode.attributes.text.indexOf('\n\n'))
+      }
     };
     createNode({
       id: createNodeId(`snippet-${sNode.meta.hash}`),

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -193,8 +193,7 @@ exports.createPages = ({ graphql, actions }) => {
           path: `/snippet${snippet.node.slug}`,
           component: snippetPage,
           context: {
-            slug: snippet.node.slug,
-            scope: `./snippets`
+            snippet: snippet.node
           }
         });
       } else {
@@ -202,8 +201,7 @@ exports.createPages = ({ graphql, actions }) => {
           path: `/archive${snippet.node.slug}`,
           component: snippetPage,
           context: {
-            slug: snippet.node.slug,
-            scope: `./snippets_archive`
+            snippet: snippet.node
           }
         });
       }

--- a/src/docs/components/SnippetCard.js
+++ b/src/docs/components/SnippetCard.js
@@ -115,13 +115,12 @@ const ShortCard = ({
     <div className='card short'>
       <CardCorner difficulty={difficulty} />
       <h4 className='card-title'>
-        
           {snippetData.title}
       </h4>
       <div
         className='card-description'
         dangerouslySetInnerHTML={{
-          __html: `${getTextualContent(snippetData.html, true)}`,
+          __html: snippetData.html,
         }}
       />
       </div>

--- a/src/docs/components/SnippetCard.js
+++ b/src/docs/components/SnippetCard.js
@@ -42,24 +42,18 @@ const CardCorner = ({ difficulty = 'intermediate' }) => (
 // ===================================================
 const FullCard = ({ snippetData, difficulty, isDarkMode }) => {
   const [examplesOpen, setExamplesOpen] = React.useState(false);
-  const tags = snippetData.tags;
-  let cardCodeHtml = `${optimizeAllNodes(
-    getCodeBlocks(snippetData.html).code,
-  )}`;
-  let cardExamplesHtml = `${optimizeAllNodes(
-    getCodeBlocks(snippetData.html).example,
-  )}`;
+
   return (
     <div className='card'>
       <CardCorner difficulty={difficulty} />
       <h4 className='card-title'>{snippetData.title}</h4>
-      {tags.map(tag => (
+      {snippetData.tags.map(tag => (
         <span className='tag' key={`tag_${tag}`}>{tag}</span>
       ))}
       <div
         className='card-description'
         dangerouslySetInnerHTML={{
-          __html: `${getTextualContent(snippetData.html)}`,
+          __html: snippetData.textHtml,
         }}
       />
       <div className='card-bottom'>
@@ -83,12 +77,9 @@ const FullCard = ({ snippetData, difficulty, isDarkMode }) => {
             aria-label='Copy to clipboard'
           />
         </CopyToClipboard>
-        {/* <button className="button button-b button-social-sh" aria-label="Share">
-          <ShareIcon />
-        </button> */}
         <pre
           className={`card-code language-${config.language}`}
-          dangerouslySetInnerHTML={{ __html: cardCodeHtml }}
+          dangerouslySetInnerHTML={{ __html: snippetData.codeHtml }}
         />
         <button
           className='button button-example-toggler'
@@ -99,7 +90,7 @@ const FullCard = ({ snippetData, difficulty, isDarkMode }) => {
           {examplesOpen && (
             <pre
               className='section card-examples language-js'
-              dangerouslySetInnerHTML={{ __html: cardExamplesHtml }}
+              dangerouslySetInnerHTML={{ __html: snippetData.exampleHtml }}
             />
           )}
       </div>

--- a/src/docs/pages/archive.js
+++ b/src/docs/pages/archive.js
@@ -11,7 +11,7 @@ import SnippetCard from '../components/SnippetCard'
 // Individual snippet category/tag page
 // ===================================================
 const ArchivePage = props => {
-  const posts = props.data.allMarkdownRemark.edges;
+  const snippets = props.data.allSnippet.edges;
 
   React.useEffect(() => {
     props.dispatch(pushNewPage('Archived', props.path));
@@ -24,17 +24,17 @@ const ArchivePage = props => {
         <h2 className='page-title'>Archived snippets</h2>
         <p className='page-sub-title'>These snippets, while useful and interesting, didn't quite make it into the repository due to either having very specific use-cases or being outdated. However we felt like they might still be useful to some readers, so here they are.</p>
         <p className='light-sub'>Click on a snippet card to view the snippet.</p>
-        {posts &&
-          posts.map(({ node }) => (
+        {snippets &&
+          snippets.map(({ node }) => (
             <SnippetCard
               key={`snippet_${node.id}`}
               short
               archived
               snippetData={{
-                title: node.frontmatter.title,
-                html: node.html,
-                tags: node.frontmatter.tags.split(',').map(v => v.trim()),
-                id: node.fields.slug.slice(1),
+                title: node.title,
+                html: node.html.text,
+                tags: node.tags.all,
+                id: node.id
               }}
               isDarkMode={props.isDarkMode}
             />
@@ -55,25 +55,19 @@ export default connect(
 )(ArchivePage);
 
 export const archivePageQuery = graphql`
-  query ArchivePage {
-    allMarkdownRemark(
-      limit: 1000
-      sort: { fields: [frontmatter___title], order: ASC }
-      filter: { fileAbsolutePath: { regex: "/snippets_archive/" }, frontmatter: {title: { ne: "" } } }
-    ) {
-      totalCount
+  query archiveListing {
+    allSnippet(filter: {archived: {eq: true}}) {
       edges {
         node {
+          title
+          html {
+            text
+          }
+          tags {
+            all
+            primary
+          }
           id
-          html
-          rawMarkdownBody
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-            tags
-          }
         }
       }
     }

--- a/src/docs/pages/index.js
+++ b/src/docs/pages/index.js
@@ -13,14 +13,7 @@ import SimpleCard from '../components/SimpleCard';
 // Home page (splash and search)
 // ===================================================
 const IndexPage = props => {
-  const snippets = props.data.snippetDataJson.data.map(snippet => ({
-    title: snippet.title,
-    html: props.data.allMarkdownRemark.edges.find(
-      v => v.node.frontmatter.title === snippet.title,
-    ).node.html,
-    tags: snippet.attributes.tags,
-    id: snippet.id
-  }));
+  const snippets = props.data.allSnippet.edges;
 
   const [searchQuery, setSearchQuery] = React.useState(props.searchQuery);
   const [searchResults, setSearchResults] = React.useState(snippets);
@@ -31,9 +24,9 @@ const IndexPage = props => {
     let results = snippets;
     if (q.trim().length)
       results = snippets.filter(
-        v =>
-          v.tags.filter(t => t.indexOf(q) !== -1).length ||
-          v.title.toLowerCase().indexOf(q) !== -1,
+        ({node}) =>
+          node.tags.all.filter(t => t.indexOf(q) !== -1).length ||
+          node.title.toLowerCase().indexOf(q) !== -1,
       );
     setSearchResults(results);
   }, [searchQuery]);
@@ -80,11 +73,16 @@ const IndexPage = props => {
               Click on a snippet card to view the snippet.
             </p>
             <h2 className='page-sub-title'>Search results</h2>
-            {searchResults.map(snippet => (
+            {searchResults.map(({node}) => (
               <SnippetCard
                 short
-                key={`snippet_${snippet.id}`}
-                snippetData={snippet}
+                key={`snippet_${node.id}`}
+                snippetData={{
+                  title: node.title,
+                  html: node.html.text,
+                  tags: node.tags.all,
+                  id: node.id
+                }}
                 isDarkMode={props.isDarkMode}
               />
             ))}
@@ -139,22 +137,17 @@ export const indexPageQuery = graphql`
         }
       }
     }
-    snippetDataJson(meta: { type: { eq: "snippetListingArray" }, scope: {eq: "./snippets"} }) {
-      data {
-        id
-        title
-        attributes {
-          tags
-        }
-      }
-    }
-    allMarkdownRemark {
+    allSnippet {
       edges {
         node {
-          html
-          frontmatter {
-            title
+          title
+          html {
+            text
           }
+          tags {
+            all
+          }
+          id
         }
       }
     }

--- a/src/docs/pages/search.js
+++ b/src/docs/pages/search.js
@@ -12,14 +12,7 @@ import SnippetCard from '../components/SnippetCard';
 // Search page
 // ===================================================
 const SearchPage = props => {
-  const snippets = props.data.snippetDataJson.data.map(snippet => ({
-    title: snippet.title,
-    html: props.data.allMarkdownRemark.edges.find(
-      v => v.node.frontmatter.title === snippet.title,
-    ).node.html,
-    tags: snippet.attributes.tags,
-    id: snippet.id,
-  }));
+  const snippets = props.data.allSnippet.edges;
 
   const [searchQuery, setSearchQuery] = React.useState(props.searchQuery);
   const [searchResults, setSearchResults] = React.useState(snippets);
@@ -30,9 +23,9 @@ const SearchPage = props => {
     let results = snippets;
     if (q.trim().length)
       results = snippets.filter(
-        v =>
-          v.tags.filter(t => t.indexOf(q) !== -1).length ||
-          v.title.toLowerCase().indexOf(q) !== -1,
+        ({ node }) =>
+          node.tags.all.filter(t => t.indexOf(q) !== -1).length ||
+          node.title.toLowerCase().indexOf(q) !== -1,
       );
     setSearchResults(results);
   }, [searchQuery]);
@@ -75,11 +68,16 @@ const SearchPage = props => {
         ) : (
           <>
             <h2 className='page-sub-title'>Search results</h2>
-            {searchResults.map(snippet => (
+            {searchResults.map(({node}) => (
               <SnippetCard
-                key={`snippet_${snippet.id}`}
+                key={`snippet_${node.id}`}
                 short
-                snippetData={snippet}
+                snippetData={{
+                  title: node.title,
+                  html: node.html.text,
+                  tags: node.tags.all,
+                  id: node.id
+                }}
                 isDarkMode={props.isDarkMode}
               />
             ))}
@@ -102,22 +100,17 @@ export default connect(
 
 export const searchPageQuery = graphql`
   query searchSnippetList {
-    snippetDataJson(meta: { type: { eq: "snippetListingArray" }, scope: {eq: "./snippets"} }) {
-      data {
-        id
-        title
-        attributes {
-          tags
-        }
-      }
-    }
-    allMarkdownRemark { 
+    allSnippet {
       edges {
-        node { 
-          html
-          frontmatter {
-            title
+        node {
+          title
+          html {
+            text
           }
+          tags {
+            all
+          }
+          id
         }
       }
     }

--- a/src/docs/templates/SnippetPage.js
+++ b/src/docs/templates/SnippetPage.js
@@ -11,7 +11,7 @@ import BackArrowIcon from '../components/SVGs/BackArrowIcon';
 // Individual snippet page template
 // ===================================================
 const SnippetPage = props => {
-  const snippet = props.data.snippet;
+  const snippet = props.pageContext.snippet;
 
   return (
     <>
@@ -50,35 +50,3 @@ export default connect(
   }),
   null,
 )(SnippetPage);
-
-export const pageQuery = graphql`
-  query SnippetBySlug($slug: String!) {
-    logo: file(absolutePath: { regex: "/logo_reverse_md.png/" }) {
-      id
-      childImageSharp {
-        fixed(height: 45, width: 45) {
-          src
-        }
-      }
-    }
-    snippet (slug: {eq: $slug }) {
-      title
-      html {
-        full
-        code
-        example
-        text
-      }
-      code {
-        src
-      }
-      tags {
-        all
-      }
-      title
-      text {
-        short
-      }
-    }
-  }
-`;

--- a/src/docs/templates/SnippetPage.js
+++ b/src/docs/templates/SnippetPage.js
@@ -11,14 +11,11 @@ import BackArrowIcon from '../components/SVGs/BackArrowIcon';
 // Individual snippet page template
 // ===================================================
 const SnippetPage = props => {
-  const post = props.data.markdownRemark;
-  const postData = props.data.snippetDataJson.data.find(
-    v => v.title === post.frontmatter.title,
-  );
+  const snippet = props.data.snippet;
 
   return (
     <>
-      <Meta title={post.frontmatter.title} description={post.excerpt} />
+      <Meta title={snippet.title} description={snippet.text.short} />
       <Shell>
         <Link
           className='link-back'
@@ -29,10 +26,13 @@ const SnippetPage = props => {
         </Link>
         <SnippetCard
           snippetData={{
-            title: postData.title,
-            html: post.html,
-            code: postData.attributes.codeBlocks.code,
-            tags: postData.attributes.tags,
+            title: snippet.title,
+            html: snippet.html.full,
+            codeHtml: snippet.html.code,
+            exampleHtml: snippet.html.example,
+            textHtml: snippet.html.text,
+            code: snippet.code.src,
+            tags: snippet.tags.all,
           }}
           isDarkMode={props.isDarkMode}
         />
@@ -52,7 +52,7 @@ export default connect(
 )(SnippetPage);
 
 export const pageQuery = graphql`
-  query BlogPostBySlug($slug: String!, $scope: String!) {
+  query SnippetBySlug($slug: String!) {
     logo: file(absolutePath: { regex: "/logo_reverse_md.png/" }) {
       id
       childImageSharp {
@@ -61,42 +61,23 @@ export const pageQuery = graphql`
         }
       }
     }
-    allMarkdownRemark {
-      edges {
-        node {
-          fields {
-            slug
-          }
-          fileAbsolutePath
-          frontmatter {
-            title
-          }
-        }
+    snippet (slug: {eq: $slug }) {
+      title
+      html {
+        full
+        code
+        example
+        text
       }
-    }
-    markdownRemark(fields: { slug: { eq: $slug } }) {
-      id
-      fields {
-        slug
+      code {
+        src
       }
-      excerpt(pruneLength: 160)
-      html
-      frontmatter {
-        title
+      tags {
+        all
       }
-    }
-    snippetDataJson(meta: { type: { eq: "snippetArray" }, scope: {eq: $scope} }) {
-      data {
-        title
-        id
-        attributes {
-          text
-          codeBlocks {
-            es6
-            example
-          }
-          tags
-        }
+      title
+      text {
+        short
       }
     }
   }

--- a/src/docs/templates/TagPage.js
+++ b/src/docs/templates/TagPage.js
@@ -13,8 +13,8 @@ import { capitalize, getRawCodeBlocks as getCodeBlocks } from '../util';
 // Individual snippet category/tag page
 // ===================================================
 const TagRoute = props => {
-  const posts = props.data.allMarkdownRemark.edges;
   const tag = props.pageContext.tag;
+  const snippets = props.pageContext.snippets;
 
   React.useEffect(() => {
     props.dispatch(pushNewPage(capitalize(tag), props.path));
@@ -26,16 +26,16 @@ const TagRoute = props => {
       <Shell>
         <h2 className='page-title'>{capitalize(tag)}</h2>
         <p className='light-sub'>Click on a snippet card to view the snippet.</p>
-        {posts &&
-          posts.map(({ node }) => (
+        {snippets &&
+          snippets.map(snippet => (
             <SnippetCard
-              key={`snippet_${node.id}`}
+              key={`snippet_${snippet.id}`}
               short
               snippetData={{
-                title: node.frontmatter.title,
-                html: node.html,
-                tags: node.frontmatter.tags.split(',').map(v => v.trim()),
-                id: node.fields.slug.slice(1),
+                title: snippet.title,
+                html: snippet.html,
+                tags: snippet.tags,
+                id: snippet.id,
               }}
               isDarkMode={props.isDarkMode}
             />
@@ -54,28 +54,3 @@ export default connect(
   }),
   null,
 )(TagRoute);
-
-export const tagPageQuery = graphql`
-  query TagPage($tagRegex: String) {
-    allMarkdownRemark(
-      limit: 1000
-      sort: { fields: [frontmatter___title], order: ASC }
-      filter: { fileAbsolutePath: { regex: "/snippets(?!_archive)/" }, frontmatter: { tags: { regex: $tagRegex } } }
-    ) {
-      totalCount
-      edges {
-        node {
-          id
-          html
-          fields {
-            slug
-          }
-          frontmatter {
-            title
-            tags
-          }
-        }
-      }
-    }
-  }
-`;


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description

After migrating this and other repositories to the new infrastructure, we realized that there are performance issues, mainly due to the way much of our codebase is structured and how all the moving parts come together. In order to solve this issue, I took the time to set up a custom schema in GraphQL, providing some major performance improvements, while also paving the way for future updates to the webite(s).

<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->

## PR Type
- [ ] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [x] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
