### PR TITLE
[FIX] Update hasKey snippet to handle failing scenario and add new tests

### DIFF
--- a/snippets/hasKey.md
+++ b/snippets/hasKey.md
@@ -1,21 +1,25 @@
 ---
 title: hasKey
-tags: object,recursion,intermediate
+tags: object,intermediate
 ---
 
 Returns `true` if the target value exists in a JSON object, `false` otherwise.
+Accepts target object as first parameter and list of string keys as second parameter.
 
-Check if the key contains `.`, use `String.prototype.split('.')[0]` to get the first part and store as `_key`.
-Use `typeof` to check if the contents of `obj[key]` are an `object` and, if so, call `hasKey` with that object and the remainder of the `key`.
-Otherwise, use `Object.keys(obj)` in combination with `Array.prototype.includes()` to check if the given `key` exists.
+Check if the list of keys is non-empty and use `Array.prototype.every()` to sequentially check
+keys from given key list to internal depth of the object. Use `Object.prototype.hasOwnProperty()` to check if current object does not have
+current key or is not an object at all then stop propagation and return `false`, else assign inner
+value as the new object to `obj` to use it next time. Return `true` on completion.
+
+Return `false` beforehand if given key list is empty.
 
 ```js
-const hasKey = (obj, key) => {
-  if (key.includes('.')) {
-    let _key = key.split('.')[0];
-    if (typeof obj[_key] === 'object') return hasKey(obj[_key], key.slice(key.indexOf('.') + 1));
-  }
-  return Object.keys(obj).includes(key);
+const hasKey = (obj, keys) => {
+  return (keys.length > 0) && keys.every((key) => {
+    if (typeof obj !== 'object' || !obj.hasOwnProperty(key)) return false;
+    obj = obj[key];
+    return true;
+  });
 };
 ```
 
@@ -23,12 +27,13 @@ const hasKey = (obj, key) => {
 let obj = {
   a: 1,
   b: { c: 4 },
-  'd.e': 5
+  'b.d': 5,
 };
-hasKey(obj, 'a'); // true
-hasKey(obj, 'b'); // true
-hasKey(obj, 'b.c'); // true
-hasKey(obj, 'd.e'); // true
-hasKey(obj, 'd'); // false
-hasKey(obj, 'f'); // false
+hasKey(obj, ['a']); // true
+hasKey(obj, ['b']); // true
+hasKey(obj, ['b', 'c']); // true
+hasKey(obj, ['b.d']); // true
+hasKey(obj, ['d']); // false
+hasKey(obj, ['c']); // false
+hasKey(obj, ['b', 'f']); // false
 ```

--- a/snippets/hasKey.md
+++ b/snippets/hasKey.md
@@ -4,12 +4,10 @@ tags: object,intermediate
 ---
 
 Returns `true` if the target value exists in a JSON object, `false` otherwise.
-Accepts target object as first parameter and list of string keys as second parameter.
 
-Check if the list of keys is non-empty and use `Array.prototype.every()` to sequentially check
-keys from given key list to internal depth of the object. Use `Object.prototype.hasOwnProperty()` to check if current object does not have
-current key or is not an object at all then stop propagation and return `false`, else assign inner
-value as the new object to `obj` to use it next time. Return `true` on completion.
+Check if `keys` is non-empty and use `Array.prototype.every()` to sequentially check its keys to internal depth of the object, `obj`. 
+Use `Object.prototype.hasOwnProperty()` to check if `obj` does not have the current key or is not an object, stop propagation and return `false`.
+Otherwise assign the key's value to `obj` to use on the next iteration.
 
 Return `false` beforehand if given key list is empty.
 

--- a/test/hasKey.test.js
+++ b/test/hasKey.test.js
@@ -1,7 +1,10 @@
 const {hasKey} = require('./_30s.js');
 
 const data = {
-  a: 1, b: { c: 4 }, 'd.e': 5
+  a: 1,
+  b: { c: 4 },
+  'd.e': 5,
+  'b.d': 2,
 };
 
 test('hasKey is a Function', () => {
@@ -9,25 +12,33 @@ test('hasKey is a Function', () => {
 });
 
 test('hasKey returns true for simple property', () => {
-  expect(hasKey(data, 'a')).toBe(true);
+  expect(hasKey(data, ['a'])).toBe(true);
 });
 
 test('hasKey returns true for object property', () => {
-  expect(hasKey(data, 'b')).toBe(true);
+  expect(hasKey(data, ['b'])).toBe(true);
 });
 
 test('hasKey returns true for nested property', () => {
-  expect(hasKey(data, 'b.c')).toBe(true);
+  expect(hasKey(data, ['b', 'c'])).toBe(true);
 });
 
 test('hasKey returns true for property with dots', () => {
-  expect(hasKey(data, 'd.e')).toBe(true);
+  expect(hasKey(data, ['d.e'])).toBe(true);
+});
+
+test('hasKey returns true for property with dots and same sibling key', () => {
+  expect(hasKey(data, ['b.d'])).toBe(true);
 });
 
 test('hasKey returns false for non-existent property', () => {
-  expect(hasKey(data, 'f')).toBe(true);
+  expect(hasKey(data, ['f'])).toBe(false);
 });
 
 test('hasKey returns false for virtual nested property', () => {
-  expect(hasKey(data, 'd')).toBe(false);
+  expect(hasKey(data, ['d'])).toBe(false);
+});
+
+test('hasKey returns false for empty key list', () => {
+  expect(hasKey(data, [])).toBe(false);
 });


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
[hasKey](https://github.com/30-seconds/30-seconds-of-code#haskey) snippet is really handy to check for inner keys in nested objects. Unfortunately current implementation of it fails for a particular case:
(Where one key is prefix of another and it has object value, in this case `b` & `b.c`)
```
let obj = {
  'a': 1,
  'b': { 'e': 4 },
  'b.c': 5
};

hasKey(obj, 'b.c');
// should return "true" but returns "false"
```

The above scenario can not be handled with current method signature of accepting second argument as string. Using function signature where it accepts Array of keys, we can address above scenario along with other simpler cases.

This also simplifies overall implementation of function without using any recursion or string manipulations. With Array as key list, we can use `Array.prototype.every()` to simplify and early return on failure.

---

<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
This PR updates [hasKey](https://github.com/30-seconds/30-seconds-of-code#haskey) snippet to handle this failing cases along with existing ones and simplifies overall implementation of the function.
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
This changes signature of [hasKey](https://github.com/30-seconds/30-seconds-of-code#haskey) snippet to accept list of strings instead of just a string, which can be called as a breaking change.


## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specifiy in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.
