### PR TITLE
[FIX] Correctly implement luhnCheck

### DIFF
--- a/dist/_30s.es5.js
+++ b/dist/_30s.es5.js
@@ -1486,7 +1486,7 @@
     });
     var lastDigit = arr.splice(0, 1)[0];
     var sum = arr.reduce(function (acc, val, i) {
-      return i % 2 !== 0 ? acc + val : acc + val * 2 % 9 || 9;
+      return i % 2 !== 0 ? acc + val : acc + (val * 2 > 9 ? val * 2 - 9 : val * 2);
     }, 0);
     sum += lastDigit;
     return sum % 10 === 0;

--- a/dist/_30s.esm.js
+++ b/dist/_30s.esm.js
@@ -706,7 +706,7 @@ const luhnCheck = num => {
     .reverse()
     .map(x => parseInt(x));
   let lastDigit = arr.splice(0, 1)[0];
-  let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + ((val * 2) % 9) || 9), 0);
+  let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + (val * 2 > 9 ? val * 2 - 9 : val * 2)), 0);
   sum += lastDigit;
   return sum % 10 === 0;
 };

--- a/dist/_30s.js
+++ b/dist/_30s.js
@@ -712,7 +712,7 @@
       .reverse()
       .map(x => parseInt(x));
     let lastDigit = arr.splice(0, 1)[0];
-    let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + ((val * 2) % 9) || 9), 0);
+    let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + (val * 2 > 9 ? val * 2 - 9 : val * 2)), 0);
     sum += lastDigit;
     return sum % 10 === 0;
   };

--- a/test/_30s.js
+++ b/test/_30s.js
@@ -709,7 +709,7 @@ const luhnCheck = num => {
     .reverse()
     .map(x => parseInt(x));
   let lastDigit = arr.splice(0, 1)[0];
-  let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + ((val * 2) % 9) || 9), 0);
+  let sum = arr.reduce((acc, val, i) => (i % 2 !== 0 ? acc + val : acc + (val * 2 > 9 ? val * 2 - 9 : val * 2)), 0);
   sum += lastDigit;
   return sum % 10 === 0;
 };

--- a/test/luhnCheck.test.js
+++ b/test/luhnCheck.test.js
@@ -3,10 +3,16 @@ const {luhnCheck} = require('./_30s.js');
 test('luhnCheck is a Function', () => {
   expect(luhnCheck).toBeInstanceOf(Function);
 });
-test('validates identification number', () => {
-  expect(luhnCheck(6011329933655299)).toBeFalsy();
+test('invalidates an incorrect identification number', () => {
+  expect(luhnCheck(6011329933655298)).toBeFalsy();
 });
-test('validates identification number', () => {
+test('validates a correct identification number', () => {
+  expect(luhnCheck(6011329933655299)).toBeTruthy();
+});
+test('validates a correct identification number', () => {
+  expect(luhnCheck(5105105105105100)).toBeTruthy();
+});
+test('validates a correct identification number', () => {
   expect(luhnCheck('4485275742308327')).toBeTruthy();
 });
 test('validates identification number', () => {


### PR DESCRIPTION
<!-- Use a descriptive title, prefix it with [FIX], [FEATURE] or [ENHANCEMENT] if applicable (use only one) -->

## Description
<!-- Write a detailed description of your changes/additions here -->
<!-- If your PR resolves an issue, please state "Resolves #(issue number)" to help maintainers process it faster -->
<!-- If you think your PR will cause breaking changes, require changes in the documentation etc, please be so kind as to explain what, where and how -->
Resolves #1084.

As explained in the issue, the `acc + ((val * 2) % 9) || 9)` logic in the function makes it so if even if the acc should equal zero it gets set to 9, which messes up the rest of the calculation. You can see this happening here:
<img width="187" alt="Screen Shot 2020-02-07 at 3 17 33 PM" src="https://user-images.githubusercontent.com/7979579/74066667-29f83380-49bd-11ea-8930-58610c970a0b.png">


## PR Type
- [x] Snippets, Tests & Tags (new snippets, updated snippets, re-tagging of snippets, added/updated tests)
- [ ] Tools, Scripts & Automation (anything related to files in the scripts folder, Gatsby, website, Travis CI or Netlify)
- [ ] General, Typos, Misc. & Meta (everything related to content, typos, general stuff and meta files in the repository - e.g. the issue template)
- [ ] Other (please specify in the description above)

## Guidelines
- [x] I have read the guidelines in the [CONTRIBUTING](https://github.com/30-seconds/30-seconds-of-code/blob/master/CONTRIBUTING.md) document.

**PLEASE NOTE:** I wasn't able to find out how to properly update `_30s.es5.min.js`, every tool I used ending up adding extra quotes that would have changed a lot of the file rather than just the `luhnCheck` function. If someone could help me out with that it'd be great.