### PR TITLE
fix: counter error course of browser property

### DIFF
--- a/snippets/counter.md
+++ b/snippets/counter.md
@@ -5,26 +5,45 @@ tags: browser,advanced
 
 Creates a counter with the specified range, step and duration for the specified selector.
 
-Check if `step` has the proper sign and change it accordingly.
+Inscrease and reduce.
+Base the duration and browser property,step may change.
 Use `setInterval()` in combination with `Math.abs()` and `Math.floor()` to calculate the time between each new text draw.
 Use `document.querySelector().innerHTML` to update the value of the selected element.
 Omit the fourth parameter, `step`, to use a default step of `1`.
 Omit the fifth parameter, `duration`, to use a default duration of `2000`ms.
 
 ```js
-const counter = (selector, start, end, step = 1, duration = 2000) => {
-  let current = start,
-    _step = (end - start) * step < 0 ? -step : step,
-    timer = setInterval(() => {
-      current += _step;
-      document.querySelector(selector).innerHTML = current;
-      if (current >= end) document.querySelector(selector).innerHTML = end;
-      if (current >= end) clearInterval(timer);
-    }, Math.abs(Math.floor(duration / (end - start))));
+const counter = ({selector, start, end, step, duration = 2000} = options) => {
+  let current = start;
+  const startTime = Date.now();
+  let _step = step > 0 ? step : 1;
+  const needStepCount = Math.abs(end - start) / _step;
+  const DOM_MIN_TIMEOUT_VALUE = 4;
+  const maxCount = duration / DOM_MIN_TIMEOUT_VALUE;
+  const ActuallyCount = Math.min(needStepCount, maxCount);
+  const timeLength = duration / ActuallyCount;
+  _step = Math.abs(end - start) / ActuallyCount;
+  const flag = end - start > 0 ? 1 : -1;
+  const dom = document.querySelector(selector);
+  const timer = setInterval(() => {
+    current += flag * _step;
+    dom.innerHTML = current;
+    const ifEnd = (flag === 1 && current >= end) || (flag === -1 && current <= end);
+    if (ifEnd){
+      dom.innerHTML = end;
+      clearInterval(timer);
+    };
+  }, timeLength);
   return timer;
 };
 ```
 
 ```js
-counter('#my-id', 1, 1000, 5, 2000); // Creates a 2-second timer for the element with id="my-id"
+counter({
+  selector: '#my-id',
+  start: 1,
+  end: 1000,
+  step: 5,
+  duration: 2000
+}); // Creates a 2-second timer for the element with id="my-id"
 ```


### PR DESCRIPTION
**counter**
Because of the browser 's property, setTimeout will work after at least 4ms ,so 
```js
counter('#logo-default',1, 2000,1, 2000)
```
will use 8000ms while done.

