### PR TITLE
Fix issue #1175 and cater additional scenarios

### DIFF
--- a/snippets/unflattenObject.md
+++ b/snippets/unflattenObject.md
@@ -5,29 +5,27 @@ tags: object,advanced
 
 Unflatten an object with the paths for keys.
 
-- Use `Object.keys(obj)` combined with `Array.prototype.reduce()` to convert flattened path node to a leaf node.
-- If the value of a key contains a dot delimiter (`.`), use `Array.prototype.split('.')`, string transformations and `JSON.parse()` to create an object, then `Object.assign()` to create the leaf node.
-- Otherwise, add the appropriate key-value pair to the accumulator object.
+- Iterate over the object keys using `Object.keys(obj)` and `Array.prototype.forEach()`.
+- Split each key with a dot delimiter (`.`) using `Array.prototype.split('.')`and use `Array.prototype.reduce()` to convert flattened paths to leaf node.
+- If the current accumulator already contains value against a particular key, return its value as the next accumulator.
+- Otherwise, add the appropriate key-value pair to the accumulator object and return value as the accumulator.
+
 
 ```js
-const unflattenObject = obj =>
-  Object.keys(obj).reduce((acc, k) => {
-    if (k.indexOf('.') !== -1) {
-      const keys = k.split('.');
-      Object.assign(
-        acc,
-        JSON.parse(
-          '{' +
-            keys.map((v, i) => (i !== keys.length - 1 ? `"${v}":{` : `"${v}":`)).join('') +
-            obj[k] +
-            '}'.repeat(keys.length)
-        )
-      );
-    } else acc[k] = obj[k];
-    return acc;
-  }, {});
+const unflattenObject = obj =>{
+    var result = {}
+    Object.keys(obj).forEach((k)=>{
+      var keys = k.split('.')
+      keys.reduce(function(acc, e, i) {
+        return acc[e] || (acc[e] = isNaN(Number(keys[i + 1])) ? (keys.length - 1 === i ? obj[k] : {}) : [])
+      }, result)
+    })
+    return result
+}
 ```
 
 ```js
 unflattenObject({ 'a.b.c': 1, d: 1 }); // { a: { b: { c: 1 } }, d: 1 }
+unflattenObject({ 'a.b': 1, 'a.c': 2, d: 3 }); // { a: { b: 1, c: 2 }, d: 3 }
+unflattenObject({ 'a.b.0': 8, d: 3 }) //{ a: { b: [ 8 ] }, d: 3 }
 ```

--- a/snippets/unflattenObject.md
+++ b/snippets/unflattenObject.md
@@ -6,18 +6,25 @@ tags: object,advanced
 Unflatten an object with the paths for keys.
 
 - Use nested `Array.prototype.reduce()` to convert the flat path to a leaf node.
-- Split each key with a dot delimiter (`.`) using `Array.prototype.split('.')`and use `Array.prototype.reduce()` to add or objects against the keys.
-- If the current accumulator already contains value against a particular key, return its value as the next accumulator.
-- Otherwise, add the appropriate key-value pair to the accumulator object and return value as the accumulator.
+- Use `String.prototype.split('.')` to split each key with a dot delimiter and `Array.prototype.reduce()` to add objects against the keys.
+- If the current accumulator already contains a value against a particular key, return its value as the next accumulator.
+- Otherwise, add the appropriate key-value pair to the accumulator object and return the value as the accumulator.
+
 ```js
-const unflattenObject = obj =>{
-    return Object.keys(obj).reduce((res , k)=>{
-      k.split('.').reduce(function(acc, e, i , keys) {
-        return acc[e] || (acc[e] = isNaN(Number(keys[i + 1])) ? (keys.length - 1 === i ? obj[k] : {}) : []);
-      }, res)
-      return res;
-    },{});
-}
+const unflattenObject = obj =>
+  Object.keys(obj).reduce((res, k) => {
+    k.split('.').reduce(
+      (acc, e, i, keys) =>
+        acc[e] ||
+        (acc[e] = isNaN(Number(keys[i + 1]))
+          ? keys.length - 1 === i
+            ? obj[k]
+            : {}
+          : []),
+      res
+    );
+    return res;
+  }, {});
 ```
 
 ```js

--- a/snippets/unflattenObject.md
+++ b/snippets/unflattenObject.md
@@ -11,11 +11,11 @@ Unflatten an object with the paths for keys.
 - Otherwise, add the appropriate key-value pair to the accumulator object and return value as the accumulator.
 ```js
 const unflattenObject = obj =>{
-    return Object.keys(obj).reduce((acc1 , k)=>{
+    return Object.keys(obj).reduce((res , k)=>{
       k.split('.').reduce(function(acc, e, i , keys) {
         return acc[e] || (acc[e] = isNaN(Number(keys[i + 1])) ? (keys.length - 1 === i ? obj[k] : {}) : []);
-      }, acc1)
-      return acc1;
+      }, res)
+      return res;
     },{});
 }
 ```

--- a/snippets/unflattenObject.md
+++ b/snippets/unflattenObject.md
@@ -5,8 +5,8 @@ tags: object,advanced
 
 Unflatten an object with the paths for keys.
 
-- Iterate over the object keys using `Object.keys(obj)` and `Array.prototype.forEach()`.
-- Split each key with a dot delimiter (`.`) using `Array.prototype.split('.')`and use `Array.prototype.reduce()` to convert flattened paths to leaf node.
+- Use nested `Array.prototype.reduce()` to convert the flat path to a leaf node.
+- Split each key with a dot delimiter (`.`) using `Array.prototype.split('.')`and use `Array.prototype.reduce()` to add or objects against the keys.
 - If the current accumulator already contains value against a particular key, return its value as the next accumulator.
 - Otherwise, add the appropriate key-value pair to the accumulator object and return value as the accumulator.
 ```js

--- a/snippets/unflattenObject.md
+++ b/snippets/unflattenObject.md
@@ -9,18 +9,14 @@ Unflatten an object with the paths for keys.
 - Split each key with a dot delimiter (`.`) using `Array.prototype.split('.')`and use `Array.prototype.reduce()` to convert flattened paths to leaf node.
 - If the current accumulator already contains value against a particular key, return its value as the next accumulator.
 - Otherwise, add the appropriate key-value pair to the accumulator object and return value as the accumulator.
-
-
 ```js
 const unflattenObject = obj =>{
-    var result = {}
-    Object.keys(obj).forEach((k)=>{
-      var keys = k.split('.')
-      keys.reduce(function(acc, e, i) {
-        return acc[e] || (acc[e] = isNaN(Number(keys[i + 1])) ? (keys.length - 1 === i ? obj[k] : {}) : [])
-      }, result)
-    })
-    return result
+    return Object.keys(obj).reduce((acc1 , k)=>{
+      k.split('.').reduce(function(acc, e, i , keys) {
+        return acc[e] || (acc[e] = isNaN(Number(keys[i + 1])) ? (keys.length - 1 === i ? obj[k] : {}) : []);
+      }, acc1)
+      return acc1;
+    },{});
 }
 ```
 


### PR DESCRIPTION
**The Issue(s)**

As shared in [issue#1175](https://github.com/30-seconds/30-seconds-of-code/issues/1175). The current code fails to restore nested properties and doesnot cater for scenairos like
```js
unflattenObject({ 'a.b': 1, 'a.c': 2, d: 3 })
unflattenObject({ 'a.b': 'foo', d: 3 })
```
where either the same key is being refered more than once or the values are non numbers. More detials can be seen in [this](https://runkit.com/tbasse/5f2a9929c9b5c9001a4d3a6e) runkit shared in the issue as well.

An additional scenario which the code failed to handle was when the flat path reffered to particular indices in the arrays values against a key. For example.
```js
unflattenObject({ 'a.b.0': 5, d: 3 })
```
should return something like `{a:{b:[5]}, d: 3}`. However, the code fails to compile.


**Solution**

I fixed the snippet to handle these scenarios along with some improvements. The updated code which passes all these tests can be seen in [this](https://runkit.com/taimoor0217/unflattenobject) runkit.

**Modifications / Improvements**

The previous code uses `JSON.parse()` to parse the manually built string into JSON and then merges it with the accumulator using `Object.assign()`. This happened for ever iteration of `Array.prototype.reduce()`. My code takes a slightly different approach of making the reference to the values as the next accumulator. This ways, I can directly mutate and nested objects without having to merge on each iteration. This arguably improves the performance fo the code.


