### PR TITLE
Added wordWrap snippet and fixed typos

### DIFF
--- a/snippets/normalizeLineEndings.md
+++ b/snippets/normalizeLineEndings.md
@@ -6,13 +6,13 @@ tags: array,intermediate
 Normalizes line endings in a string.
 
 - Use `String.prototype.replace()` and a regular expression to match and replace line endings with the `normalized` version.
-- Omit the seconds argument, `normalized`, to use the default value of `'\r\n'`.
+- Omit the second argument, `normalized`, to use the default value of `'\r\n'`.
 
 ```js
 const normalizeLineEndings = (str, normalized = '\r\n') => str.replace(/\r?\n/g, normalized);
 ```
 
 ```js
-splitLines('This\r\nis a\nmultiline\nstring.\r\n'); // 'This\r\nis a\r\nmultiline\r\nstring.\r\n'
-splitLines('This\r\nis a\nmultiline\nstring.\r\n', '\n'); // 'This\nis a\nmultiline\nstring.\n'
+normalizeLineEndings('This\r\nis a\nmultiline\nstring.\r\n'); // 'This\r\nis a\r\nmultiline\r\nstring.\r\n'
+normalizeLineEndings('This\r\nis a\nmultiline\nstring.\r\n', '\n'); // 'This\nis a\nmultiline\nstring.\n'
 ```

--- a/snippets/toTitleCase.md
+++ b/snippets/toTitleCase.md
@@ -1,6 +1,6 @@
 ---
 title: toTitleCase
-tags: string,regepx,intermediate
+tags: string,regexp,intermediate
 ---
 
 Converts a string to title case.

--- a/snippets/wordWrap.md
+++ b/snippets/wordWrap.md
@@ -9,12 +9,12 @@ Wraps a string to a given number of characters using a string break character.
 - Omit the third argument, `br`, to use the default value of `'\n'`.
 
 ```js
-const wordWrap = (s, max, br = '\n') => s.replace(
-    new RegExp(`(?![^\\n]{1,${max}}$)([^\\n]{1,${max}})\\s`, 'g'), '$1' + br
+const wordWrap = (str, max, br = '\n') => str.replace(
+  new RegExp(`(?![^\\n]{1,${max}}$)([^\\n]{1,${max}})\\s`, 'g'), '$1' + br
 );
 ```
 
 ```js
-wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32) // 'Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.\nFusce tempus.'
-wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32, '\r\n') // 'Lorem ipsum dolor sit amet,\r\nconsectetur adipiscing elit.\r\nFusce tempus.'
+wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32); // 'Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.\nFusce tempus.'
+wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32, '\r\n'); // 'Lorem ipsum dolor sit amet,\r\nconsectetur adipiscing elit.\r\nFusce tempus.'
 ```

--- a/snippets/wordWrap.md
+++ b/snippets/wordWrap.md
@@ -1,0 +1,20 @@
+---
+title: wordWrap
+tags: string,regexp,intermediate
+---
+
+Wraps a string to a given number of characters using a string break character.
+
+- Use `String.prototype.replace()` and a regular expression to insert a given break character at the nearest whitespace of `max` characters.
+- Omit the third argument, `br`, to use the default value of `'\n'`.
+
+```js
+const wordWrap = (s, max, br = '\n') => s.replace(
+    new RegExp(`(?![^\\n]{1,${max}}$)([^\\n]{1,${max}})\\s`, 'g'), '$1' + br
+);
+```
+
+```js
+wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32) // 'Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit.\nFusce tempus.'
+wordWrap('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce tempus.', 32, '\r\n') // 'Lorem ipsum dolor sit amet,\r\nconsectetur adipiscing elit.\r\nFusce tempus.'
+```


### PR DESCRIPTION
Added `wordWrap` snippet that adds break characters after words at a given maximum character. Also fixed typos in `normalizeEndings` and `toTitleCase` snippets.