### PR TITLE
Update hasKey snippet

### DIFF
--- a/snippets/hasKey.md
+++ b/snippets/hasKey.md
@@ -15,7 +15,7 @@ const hasKey = (obj, keys) => {
   return (
     keys.length > 0 &&
     keys.every(key => {
-      if (typeof obj !== 'object' || !obj.hasOwnProperty(key)) return false;
+      if (typeof obj !== 'object' || !Object.prototype.hasOwnProperty.call(obj, key) return false;
       obj = obj[key];
       return true;
     })


### PR DESCRIPTION
It is recommended to not use the `hasOwnProperty` method from the
target, the prototype of the object target could be changed very easily.
eg:

```
const meow = {
  hasOwnProperty: () => true
}
```