### PR TITLE
Update getElementsBiggerThanViewport.md

### DIFF
--- a/snippets/getElementsBiggerThanViewport.md
+++ b/snippets/getElementsBiggerThanViewport.md
@@ -6,15 +6,12 @@ tags: browser,intermediate
 Returns an array of HTML elements whose width is larger than that of the viewport's.
 
 - Use `HTMLElement.prototype.offsetWidth()` to get the width of the `document`.
-- Use `Array.prototype.reduce()` on the result of `document.querySelectorAll()` to check the width of all elements in the document.
+- Use `Array.prototype.filter()` on the result of `document.querySelectorAll()` to check the width of all elements in the document.
 
 ```js
 const getElementsBiggerThanViewport = () => {
   const docWidth = document.documentElement.offsetWidth;
-  return [...document.querySelectorAll('*')].reduce((acc, el) => {
-    if (el.offsetWidth > docWidth) acc.push(el);
-    return acc;
-  }, []);
+  return [...document.querySelectorAll('*')].filter(el => el.offsetWidth > docWidth);
 }
 ```
 


### PR DESCRIPTION
There is no reason to use `.reduce()` when when you don't need to.
`.filter()` is much simpler to reason, easier to read and more verbose