### PR TITLE
Update flatten to use latest syntax

### DIFF
--- a/snippets/flatten.md
+++ b/snippets/flatten.md
@@ -5,14 +5,10 @@ tags: array,intermediate
 
 Flattens an array up to the specified depth.
 
-- Use recursion, decrementing `depth` by 1 for each level of depth.
-- Use `Array.prototype.reduce()` and `Array.prototype.concat()` to merge elements or arrays.
-- Base case, for `depth` equal to `1` stops recursion.
-- Omit the second argument, `depth` to flatten only to a depth of `1` (single flatten).
+- Use `Array.prototype.flat`.
 
 ```js
-const flatten = (arr, depth = 1) =>
-  arr.reduce((a, v) => a.concat(depth > 1 && Array.isArray(v) ? flatten(v, depth - 1) : v), []);
+const flatten = (arr, depth = 1) => arr.flat;
 ```
 
 ```js

--- a/snippets/flatten.md
+++ b/snippets/flatten.md
@@ -8,7 +8,7 @@ Flattens an array up to the specified depth.
 - Use `Array.prototype.flat`.
 
 ```js
-const flatten = (arr, depth = 1) => arr.flat;
+const flatten = (arr, depth = 1) => arr.flat(depth);
 ```
 
 ```js


### PR DESCRIPTION
I updated the `flatten` snippet to use the latest `Array.prototype.flat` method, introduced in ES2019.