### PR TITLE
fix: allow for shorter arrays in isSorted

### DIFF
--- a/snippets/isSorted.md
+++ b/snippets/isSorted.md
@@ -3,20 +3,19 @@ title: isSorted
 tags: array,intermediate
 ---
 
-Returns `1` if the array is sorted in ascending order, `-1` if it is sorted in descending order or `0` if it is not sorted.
+Returns `1` if an array of numbers is sorted in ascending order, `-1` if it is sorted in descending order or `0` if it is not sorted.
 
-- Calculate the ordering `direction` for the first two elements.
-- Use `Object.entries()` to loop over array objects and compare them in pairs.
-- Return `0` if the `direction` changes or the `direction` if the last element is reached.
+- Calculate the ordering `direction` for every pair of adjacent array elements.
+- Return `0` if the `direction` changes or the `direction` sign if the last element is reached.
 
 ```js
 const isSorted = arr => {
-  let direction = -(arr[0] - arr[1]);
-  for (let [i, val] of arr.entries()) {
-    direction = !direction ? -(arr[i - 1] - arr[i]) : direction;
-    if (i === arr.length - 1) return !direction ? 0 : direction / Math.abs(direction);
-    else if ((val - arr[i + 1]) * direction > 0) return 0;
+  let direction = 0;
+  for (let i = 1; i < arr.length; i++) {
+    if (!direction) direction = arr[i] - arr[i - 1];
+    else if ((arr[i] - arr[i - 1]) * direction < 0) return 0;
   }
+  return Math.sign(direction);
 };
 ```
 
@@ -24,4 +23,5 @@ const isSorted = arr => {
 isSorted([0, 1, 2, 2]); // 1
 isSorted([4, 3, 2]); // -1
 isSorted([4, 3, 5]); // 0
+isSorted([4]); // 0
 ```

--- a/snippets/isSorted.md
+++ b/snippets/isSorted.md
@@ -3,17 +3,18 @@ title: isSorted
 tags: array,intermediate
 ---
 
-Returns `1` if an array of numbers is sorted in ascending order, `-1` if it is sorted in descending order or `0` if it is not sorted.
+Returns `1` if a numeric array is sorted in ascending order, `-1` if it is sorted in descending order or `0` if it is not sorted.
 
-- Calculate the ordering `direction` for every pair of adjacent array elements.
-- Return `0` if the `direction` changes or the `direction` sign if the last element is reached.
+- Calculate the ordering `direction` for the first pair of adjacent array elements.
+- Return `0` if the given array is empty, only has one element or the `direction` changes for any pair of adjacent array elements.
+- Use `Math.sign()` to covert the final value of `direction` to `-1` or `1`.
 
 ```js
 const isSorted = arr => {
-  let direction = 0;
-  for (let i = 1; i < arr.length; i++) {
-    if (!direction) direction = arr[i] - arr[i - 1];
-    else if ((arr[i] - arr[i - 1]) * direction < 0) return 0;
+  if (arr.length <= 1) return 0;
+  const direction = arr[1] - arr[0];
+  for (let i = 2; i < arr.length; i++) {
+    if ((arr[i] - arr[i - 1]) * direction < 0) return 0;
   }
   return Math.sign(direction);
 };


### PR DESCRIPTION
Also add some style changes like using `Math.sign(direction)` instead of `direction / Math.abs(direction)`