### PR TITLE
Adds another example to frequencies snippet

### DIFF
--- a/snippets/frequencies.md
+++ b/snippets/frequencies.md
@@ -17,4 +17,5 @@ const frequencies = arr =>
 
 ```js
 frequencies(['a', 'b', 'a', 'c', 'a', 'a', 'b']); // { a: 4, b: 2, c: 1 }
+frequencies([...'ball']); // { b: 1, a: 1, l: 2 }
 ```


### PR DESCRIPTION
Since the `frequencies` snippet can be used to count char occurrences in strings as well, I added a new example to it