### PR TITLE
add toHSLObject

### DIFF
--- a/snippets/toHSLObject.md
+++ b/snippets/toHSLObject.md
@@ -10,12 +10,12 @@ Converts an `hsl()` color string to an object with the values of each color.
 - Use array destructuring to store the values into named variables and create an appropriate object from them.
 
 ```js
-const toHSLObject = (hslStr) => {
-  const [hue, saturation, light] = hslStr.match(/\d+/g).map(Number);
-  return { hue, saturation, light };
+const toHSLObject = hslStr => {
+  const [hue, saturation, lightness] = hslStr.match(/\d+/g).map(Number);
+  return { hue, saturation, lightness };
 };
 ```
 
 ```js
-toHSLObject("hsl(50,1,1)"); // { hue: 50, saturation: 1, light: 1 }
+toHSLObject("hsl(50,1,1)"); // { hue: 50, saturation: 1, lightness: 1 }
 ```

--- a/snippets/toHSLObject.md
+++ b/snippets/toHSLObject.md
@@ -17,5 +17,5 @@ const toHSLObject = hslStr => {
 ```
 
 ```js
-toHSLObject("hsl(50,1,1)"); // { hue: 50, saturation: 1, lightness: 1 }
+toHSLObject("hsl(50,10%,10%)"); // { hue: 50, saturation: 10, lightness: 10 }
 ```

--- a/snippets/toHSLObject.md
+++ b/snippets/toHSLObject.md
@@ -1,0 +1,21 @@
+---
+title: toHSLObject
+tags: string,browser,regexp,intermediate
+---
+
+Converts an `hsl()` color string to an object with the values of each color.
+
+- Use `String.prototype.match()` to get an array of 3 string with the numeric values.
+- Use `Array.prototype.map()` in combination with `Number` to convert them into an array of numeric values.
+- Use array destructuring to store the values into named variables and create an appropriate object from them.
+
+```js
+const toHSLObject = (hslStr) => {
+  const [hue, saturation, light] = hslStr.match(/\d+/g).map(Number);
+  return { hue, saturation, light };
+};
+```
+
+```js
+toHSLObject("hsl(50,1,1)"); // { hue: 50, saturation: 1, light: 1 }
+```


### PR DESCRIPTION
In addition to [this PR](https://github.com/30-seconds/30-seconds-of-code/pull/1616) that adds `toHSLArray` I am adding a utility function to restructure it inside an object. 

I went with full `hsl` "component" names _(hue, saturation, lightness)_ due to code readability and use cases. For example, it would be much cleaner to say `lightness * 0.5` to make it darker than doing `l * 0.5` etc. PS I also vote we do this to [`toRGBObject`](https://www.30secondsofcode.org/js/s/to-rgb-object).

Anyways to celebrate 2000 followers on our Twitter bot we made a year ago, I got this Greek candy: 


![IMG_7872](https://user-images.githubusercontent.com/25749162/96296321-6588da00-0fef-11eb-9664-20115c1f982c.jpg)
