### PR TITLE
cleaner names inside toRGBObject

### DIFF
--- a/snippets/toRGBObject.md
+++ b/snippets/toRGBObject.md
@@ -11,11 +11,11 @@ Converts an `rgb()` color string to an object with the values of each color.
 
 ```js
 const toRGBObject = rgbStr => {
-  const [r, g, b] = rgbStr.match(/\d+/g).map(Number);
-  return { r, g, b };
+  const [red, green, blue] = rgbStr.match(/\d+/g).map(Number);
+  return { red, green, blue };
 };
 ```
 
 ```js
-toRGBObject('rgb(255,12,0)'); // {r: 255, g: 12, b: 0}
+toRGBObject("rgb(255,12,0)"); // {red: 255, green: 12, blue: 0}
 ```


### PR DESCRIPTION
based on this [discussion](https://github.com/30-seconds/30-seconds-of-code/pull/1617#issuecomment-710416336) I am changing RGB object key names to something more meaningful (believe it or not, some folks don't know what values `r`, `g`, `b` stand for). It also follows the same naming pattern as `toHSLObject`. 

```diff
- {r: 255, g: 12, b: 0}
+ {red: 255, green: 12, blue: 0}
```