### PR TITLE
Adding snippet for downloading js Objects as JSON files

### DIFF
--- a/snippets/downloadObjectAsJSON.md
+++ b/snippets/downloadObjectAsJSON.md
@@ -1,0 +1,27 @@
+---
+title: downloadObjectAsJSON
+tags: function,object,advanced
+---
+
+Downloads a javascript Object/Array of objects as a JSON file
+
+- The arguments for the function are the object variable name, and a string.
+- The object variable name is the variable the you want to download.
+- The string is the file name that will be downloaded.
+- Can be used in the console if defined globally.
+
+```js
+const downloadObjectAsJSON = (exportObj, exportName) => {
+  let dataStr = `data:text/json;charset=utf-8,${encodeURIComponent(JSON.stringify(exportObj))}`;
+  let downloadAnchorNode = document.createElement('a');
+  downloadAnchorNode.setAttribute("href", dataStr);
+  downloadAnchorNode.setAttribute("download", exportName + ".json");
+  document.body.appendChild(downloadAnchorNode); // required for firefox
+  downloadAnchorNode.click();
+  downloadAnchorNode.remove();
+}
+```
+
+```js
+downloadObjectAsJSON(configObject, 'configFileName'); // configFileName.json downloads with the contents of configObject
+```


### PR DESCRIPTION
This PR includes a snippet with a function that allows users to download Javascript objects as JSON files. 

I would like this PR to be included as part of the Hacktoberfest, by labelling it as  ‘hacktoberfest-accepted’ (if accepted)

Many thanks