### PR TITLE
Use underscore for unused argument

### DIFF
--- a/snippets/initializeArrayWithRange.md
+++ b/snippets/initializeArrayWithRange.md
@@ -12,7 +12,7 @@ Initializes an array containing the numbers in the specified range where `start`
 
 ```js
 const initializeArrayWithRange = (end, start = 0, step = 1) =>
-  Array.from({ length: Math.ceil((end - start + 1) / step) }, (v, i) => i * step + start);
+  Array.from({ length: Math.ceil((end - start + 1) / step) }, (_, i) => i * step + start);
 ```
 
 ```js


### PR DESCRIPTION
Since argument v was unnecessary, it can be replaced with _.