### PR TITLE
Fix date in example

### DIFF
--- a/snippets/dayOfYear.md
+++ b/snippets/dayOfYear.md
@@ -15,5 +15,5 @@ const dayOfYear = date =>
 ```
 
 ```js
-dayOfYear(new Date()); // 272
+dayOfYear(new Date("Oct 21, 2020")); // 295
 ```


### PR DESCRIPTION
calling with `new Date()` will give different result each time. It's better to use a fixed date in example.