### PR TITLE
Issue 1683 : Add 'httpOptions' code 

### DIFF
--- a/snippets/httpOptions.md
+++ b/snippets/httpOptions.md
@@ -1,0 +1,33 @@
+---
+title: httpOptions
+tags: browser,intermediate
+---
+
+Makes a `OPTIONS` request to the passed URL.
+
+- Use the `XMLHttpRequest` web API to make a `OPTIONS` request to the given `url`.
+- Handle the `onload` event, by calling the given `callback` the `getResponseHeader()` with "Allow" or "Access-Control-Allow-Methods" Header.
+- Handle the `onerror` event, by running the provided `err` function.
+- Omit the third argument, `err`, to log errors to the console's `error` stream by default.
+
+```js
+const httpTrace = (url, callback, err = console.error) => {
+  const request = new XMLHttpRequest();
+  request.open('OPTIONS', url, true);
+  request.onload = () => callback(request.getResponseHeader("Access-Control-Allow-Methods"));
+  request.onerror = () => err(request);
+  request.send();
+};
+```
+
+```js
+httpTrace(
+  'http://jsonplaceholder.typicode.com/posts/1', 
+   request => {console.log(request.getResponseHeader("Access-Control-Allow-Methods"));} 
+);
+ /*
+Logs: {
+	GET,HEAD,PUT,PATCH,POST,DELETE
+}
+*/
+```

--- a/snippets/httpOptions.md
+++ b/snippets/httpOptions.md
@@ -11,7 +11,7 @@ Makes a `OPTIONS` request to the passed URL.
 - Omit the third argument, `err`, to log errors to the console's `error` stream by default.
 
 ```js
-const httpTrace = (url, callback, err = console.error) => {
+const httpOptions = (url, callback, err = console.error) => {
   const request = new XMLHttpRequest();
   request.open('OPTIONS', url, true);
   request.onload = () => callback(request.getResponseHeader("Access-Control-Allow-Methods"));
@@ -21,7 +21,7 @@ const httpTrace = (url, callback, err = console.error) => {
 ```
 
 ```js
-httpTrace(
+httpOptions(
   'http://jsonplaceholder.typicode.com/posts/1', 
    request => {console.log(request.getResponseHeader("Access-Control-Allow-Methods"));} 
 );


### PR DESCRIPTION
I request pull about 'httpOptions'.  Whether this code will be merged or not is up to you.
I am just happy to work for your repo.

This code is about HTTP Options method, which will return what method will be allowed on the website. 
Some people need this code to check vulnerability maybe.

It is really similar to other HTTP method code. such as httpGet, httpDelete, or httpPut. 
#1683 

Thanks