### PR TITLE
add changeLightness snippet

### DIFF
--- a/snippets/changeLightness.md
+++ b/snippets/changeLightness.md
@@ -1,14 +1,14 @@
 ---
 title: changeLightness
-tags: string,browser,regexp,beginner
+tags: string,browser,regexp,intermediate
 ---
 
-Returns the string value of the color with changed lightness in `hsl` format.
+Changes the lightness value of an `hsl()` color string.
 
-- Use `String.prototype.match()` to get an array of 3 string with the numeric values.
+- Use `String.prototype.match()` to get an array of 3 strings with the numeric values.
 - Use `Array.prototype.map()` in combination with `Number` to convert them into an array of numeric values.
-- Clamp new lightness within the hsl valid range between `0` and `100`.
-- Form a valid `hsl` color string.
+- Make sure the lightness is within the valid range (between `0` and `100`), using `Math.max()` and `Math.min()`.
+- Use a template literal to create a new `hsl()` string with the updated value.
 
 ```js
 const changeLightness = (delta, hslStr) => {
@@ -24,6 +24,6 @@ const changeLightness = (delta, hslStr) => {
 ```
 
 ```js
-changeLightness(10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 60%)' - lightens the color by 10%
-changeLightness(-10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 40%)' - darkens the color by 10%
+changeLightness(10, 'hsl(330, 50%, 50%)'); // 'hsl(330, 50%, 60%)'
+changeLightness(-10, 'hsl(330, 50%, 50%)'); // 'hsl(330, 50%, 40%)'
 ```

--- a/snippets/changeLightness.md
+++ b/snippets/changeLightness.md
@@ -1,9 +1,9 @@
 ---
-title: lighten
+title: changeLightness
 tags: string,browser,regexp,beginner
 ---
 
-Returns the string value for the lightened color in `hsl` format.
+Returns the string value of the color with changed lightness in `hsl` format.
 
 - Use `String.prototype.match()` to get an array of 3 string with the numeric values.
 - Use `Array.prototype.map()` in combination with `Number` to convert them into an array of numeric values.
@@ -11,12 +11,12 @@ Returns the string value for the lightened color in `hsl` format.
 - Form a valid `hsl` color string.
 
 ```js
-const lighten = (amount, hslStr) => {
+const changeLightness = (delta, hslStr) => {
   const [hue, saturation, lightness] = hslStr.match(/\d+/g).map(Number);
 
   const newLightness = Math.max(
     0,
-    Math.min(100, lightness + parseFloat(amount))
+    Math.min(100, lightness + parseFloat(delta))
   );
 
   return `hsl(${hue}, ${saturation}%, ${newLightness}%)`;
@@ -24,5 +24,6 @@ const lighten = (amount, hslStr) => {
 ```
 
 ```js
-lighten(10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 60%)'
+changeLightness(10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 60%)' - lightens the color by 10%
+changeLightness(-10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 40%)' - darkens the color by 10%
 ```

--- a/snippets/lighten.md
+++ b/snippets/lighten.md
@@ -1,0 +1,28 @@
+---
+title: lighten
+tags: string,browser,regexp,beginner
+---
+
+Returns the string value for the lightened color in `hsl` format.
+
+- Use `String.prototype.match()` to get an array of 3 string with the numeric values.
+- Use `Array.prototype.map()` in combination with `Number` to convert them into an array of numeric values.
+- Clamp new lightness within the hsl valid range between `0` and `100`.
+- Form a valid `hsl` color string.
+
+```js
+const lighten = (amount, hslStr) => {
+  const [hue, saturation, lightness] = hslStr.match(/\d+/g).map(Number);
+
+  const newLightness = Math.max(
+    0,
+    Math.min(100, lightness + parseFloat(amount))
+  );
+
+  return `hsl(${hue}, ${saturation}%, ${newLightness}%)`;
+};
+```
+
+```js
+lighten(10, "hsl(330, 50%, 50%)"); // 'hsl(330, 50%, 60%)'
+```


### PR DESCRIPTION
as previously discussed with @Chalarangelo I am adding a `changeLightness` snippet to provide more value to folks who are working with color. 

**Yes.** it's a simple modification of `hsl` values but too many this color theory is [_That's Greek to me._](https://en.wikipedia.org/wiki/Greek_to_me)

_**use case:**_
Modifying a single value could be done by hand, but to achieve things dynamically a user needs a method like `changeLightness`. Here is an example of dynamically generated user icons like we see on Figma or Google Docs etc.

![image](https://user-images.githubusercontent.com/25749162/97222766-2288ec80-17cf-11eb-93ca-4b7aa46d4eb4.png)
