### PR TITLE
Update takeWhile.md

### DIFF
--- a/snippets/takeWhile.md
+++ b/snippets/takeWhile.md
@@ -3,10 +3,10 @@ title: takeWhile
 tags: array,intermediate
 ---
 
-Removes elements in an array until the passed function returns `true`.
+Removes elements in an array until the passed function returns `false`.
 Returns the removed elements.
 
-- Loop through the array, using a `for...of` loop over `Array.prototype.entries()` until the returned value from the function is `true`.
+- Loop through the array, using a `for...of` loop over `Array.prototype.entries()` until the returned value from the function is `false`.
 - Return the removed elements, using `Array.prototype.slice()`.
 
 ```js

--- a/snippets/takeWhile.md
+++ b/snippets/takeWhile.md
@@ -11,11 +11,11 @@ Returns the removed elements.
 
 ```js
 const takeWhile = (arr, func) => {
-  for (const [i, val] of arr.entries()) if (func(val)) return arr.slice(0, i);
+  for (const [i, val] of arr.entries()) if (!func(val)) return arr.slice(0, i);
   return arr;
 };
 ```
 
 ```js
-takeWhile([1, 2, 3, 4], n => n >= 3); // [1, 2]
+takeWhile([1, 2, 3, 4], n => n < 3); // [1, 2]
 ```


### PR DESCRIPTION
The definition of take while seems inverted. When you use `takeWhile()`, what you really say is: out of these array elements `[1, 2, 3, 4]`, take (keep selecting) elements while an element (`n`) is less than 3.  Earlier example `takeWhile([1, 2, 3, 4], n => n >= 3);` was less intuitive as you are asking for elements greater than equal to 3 but actually expect `[1, 2]` in t=return.