### PR TITLE
Fix luhnsCheck's miscalculation for some credit card numbers

### DIFF
--- a/snippets/luhnCheck.md
+++ b/snippets/luhnCheck.md
@@ -20,8 +20,7 @@ const luhnCheck = num => {
     .map(x => parseInt(x));
   let lastDigit = arr.splice(0, 1)[0];
   let sum = arr.reduce(
-    (acc, val, i) => (i % 2 !== 0 ? acc + val : acc + ((val * 2) % 9) || 9),
-    0
+    (acc, val, i) => (i % 2 !== 0 ? acc + val : acc + ((val *= 2) > 9 ? val - 9 : val))
   );
   sum += lastDigit;
   return sum % 10 === 0;


### PR DESCRIPTION
This pull request fixes the miscalculation of the some credit card numbers and closes #1817 according to suggestion given by @tomer-gavish