### PR TITLE
Fix bubbleSort

### DIFF
--- a/snippets/bubbleSort.md
+++ b/snippets/bubbleSort.md
@@ -17,7 +17,7 @@ Sorts an array of numbers, using the bubble sort algorithm.
 const bubbleSort = arr => {
   let swapped = false;
   const a = [...arr];
-  for (let i = 1; i < a.length - 1; i++) {
+  for (let i = 1; i < a.length; i++) {
     swapped = false;
     for (let j = 0; j < a.length - i; j++) {
       if (a[j + 1] < a[j]) {


### PR DESCRIPTION
Bubble sort is not working properly.
The following returns `[2, 1, 3, 4]` instead of `[1, 2, 3, 4]`
```
bubbleSort([4, 3, 2, 1])
```
Pull request fixes this bug.