### PR TITLE
Fix : using "func" instead of "fn" as the short term for function

### DIFF
--- a/snippets/converge.md
+++ b/snippets/converge.md
@@ -11,8 +11,8 @@ Accepts a converging function and a list of branching functions and returns a fu
 - Use the spread operator (`...`) to call `converger` with the results of all other functions.
 
 ```js
-const converge = (converger, fns) => (...args) =>
-  converger(...fns.map(fn => fn.apply(null, args)));
+const converge = (converger, funcs) => (...args) =>
+  converger(...funcs.map(func => func.apply(null, args)));
 ```
 
 ```js


### PR DESCRIPTION
Assuming that "**fn**" stands for **function**, I propose to use the word "**func**". I think most people, especially beginners are more familiar to the term "**func"** instead of "**fn**" as the short term for **function**.