### PR TITLE
Added is-perm

### DIFF
--- a/snippets/python/s/is-perm.md
+++ b/snippets/python/s/is-perm.md
@@ -1,0 +1,27 @@
+---
+title: Check if two iterables are permutations of each other
+type: snippet
+language: python
+tags: [list]
+cover: apples
+dateModified: 2023-05-23 10:48:03 +0100
+---
+
+Check if two iterables are permutations of each other.
+
+- Use `Counter` to verify that each element in both iterables appear an equal number of times.
+
+```py
+from collections import Counter
+
+def is_perm(items0, items1):
+  return len(items0) == len(items1) and Counter(items0) == Counter(items1)
+```
+
+```py
+is_perm([1, 2, 3], [4, 1, 6]) # False
+is_perm([1, 2], [2, 1]) # True
+
+is_perm("dad", "add") # True
+is_perm("snack", "track") # False
+```

--- a/snippets/python/s/iterable-is-permutation.md
+++ b/snippets/python/s/iterable-is-permutation.md
@@ -1,15 +1,17 @@
 ---
 title: Check if two iterables are permutations of each other
+shortTitle: Iterable permutations
 type: snippet
 language: python
-tags: [list]
+tags: [list,string]
 cover: apples
-dateModified: 2023-05-23 10:48:03 +0100
+dateModified: 2023-05-23T10:48:03+03:00
 ---
 
 Check if two iterables are permutations of each other.
 
-- Use `Counter` to verify that each element in both iterables appear an equal number of times.
+- Use `len` to check if both iterables have the same length.
+- Use `Counter` to verify that each element appears an equal number of times in both iterables.
 
 ```py
 from collections import Counter


### PR DESCRIPTION
Added is-perm, a quick efficient way to check that two iterables are permutations of each other.