### PR TITLE
Update README.md . Block quote not matching 30secondsofcode website's heading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 30 seconds of code
 
-> Short JavaScript code snippets for all your development needs
+> Short code snippets for all your development needs
 
 * Visit [our website](https://30secondsofcode.org) to view our snippet collection.
 * Search for snippets that suit your needs. You can search by name, tag, language or using a snippet's description. Just start typing a term and see what comes up.


### PR DESCRIPTION

The website heading reads, "Discover short code snippets for all your development needs." The block quote specifies, "Short JavaScript code snippets for all your development needs" differing slightly from the main heading.It also does not match the tagline on the image of Readme.