### PR TITLE
Fix unnecessary parameters in Queue class method and elaborated on explanation

### DIFF
--- a/content/snippets/js/s/data-structures-queue.md
+++ b/content/snippets/js/s/data-structures-queue.md
@@ -35,11 +35,11 @@ class Queue {
     this.items.push(item);
   }
 
-  dequeue(item) {
+  dequeue() {
     return this.items.shift();
   }
 
-  peek(item) {
+  peek() {
     return this.items[0];
   }
 
@@ -50,7 +50,7 @@ class Queue {
 ```
 
 - Create a `class` with a `constructor` that initializes an empty array, `items`, for each instance.
-- Define an `enqueue()` method, which uses `Array.prototype.push()` to add an element to the end of the `items` array.
+- Define an `enqueue()` method, which uses `Array.prototype.push()` to add an element, `item`, to the end of the `items` array.
 - Define a `dequeue()` method, which uses `Array.prototype.shift()` to remove an element from the start of the `items` array.
 - Define a `peek()` method, which retrieves the value of the first element in the `items` array, without removing it.
 - Define an `isEmpty()` method, which uses `Array.prototype.length` to determine if the `items` array is empty.


### PR DESCRIPTION
<!-- Pull request title -->
# fix: Unnecessary parameters in Queue class methods, elaborated on explanation below

<!-- Pull request body -->
## Related Issue

Fixes #2019 

## Description

This PR removes the unnecessary, unused `item` parameter in the `dequeue()` and `peek()` methods of the Queue class in lines 38 and 42. 

Additionally, a slight elaboration is made in line 53 below, to specify that the element being added by the `enqueue()` method is the `item` argument that's passed in during function invocation. 