### PR TITLE
Set up infrastructure for prepared queries

### DIFF
--- a/src/blocks/application.js
+++ b/src/blocks/application.js
@@ -8,6 +8,7 @@ import { JSONHandler } from '#blocks/utilities/jsonHandler';
 import { YAMLHandler } from '#blocks/utilities/yamlHandler';
 import { Extractor } from '#blocks/extractor/extractor';
 import { Content } from '#blocks/utilities/content';
+import { PreparedQueries } from '#blocks/utilities/preparedQueries';
 import schema from '#blocks/schema';
 import settings from '#settings/settings';
 import writers from '#blocks/writers/writers';
@@ -480,6 +481,14 @@ export class Application {
     Application.serializerNames.forEach(serializer => {
       context[serializer] = Application.dataset.getSerializer(serializer);
     });
+    context.Query = Object.getOwnPropertyNames(PreparedQueries).reduce(
+      (queries, queryName) => {
+        if (!['name', 'length', 'prototype'].includes(queryName))
+          queries[queryName] = PreparedQueries[queryName](Application);
+        return queries;
+      },
+      {}
+    );
     context.rawDataset = Application.datasetObject;
     logger.success('Setting up REPL context complete.');
   }

--- a/src/blocks/utilities/preparedQueries.js
+++ b/src/blocks/utilities/preparedQueries.js
@@ -1,0 +1,59 @@
+const preparedQueriesCache = new Map();
+
+export class PreparedQueries {
+  /**
+   * Returns an array of (cover, count) tuples, sorted by count.
+   */
+  static coverImageUsage = application => () => {
+    if (!preparedQueriesCache.has('coverImageUsage')) {
+      const Snippet = application.dataset.getModel('Snippet');
+
+      const groupedRecords = Snippet.records.groupBy('cover');
+      const result = Object.keys(groupedRecords)
+        .map(cover => ({
+          cover,
+          count: groupedRecords[cover].length,
+        }))
+        .sort((a, b) => b.count - a.count);
+
+      preparedQueriesCache.set('coverImageUsage', result);
+    }
+    return preparedQueriesCache.get('coverImageUsage');
+  };
+
+  /**
+   * Returns an array of matching snippets based on the given options.
+   * @param {string} options.language - Language id
+   * @param {string} options.tag - Tag string
+   * @param {string} options.type - Snippet type
+   * @param {boolean} options.primary - Whether to match primary tag or any
+   */
+  static matchSnippets =
+    application =>
+    ({ language = null, tag = null, type = null, primary = false }) => {
+      const cacheKey = `matchSnippets#${language}-${tag}-${type}-${primary}`;
+
+      if (!preparedQueriesCache.has(cacheKey)) {
+        const Snippet = application.dataset.getModel('Snippet');
+        const queryMatchers = [];
+
+        if (type)
+          if (type === 'article') {
+            queryMatchers.push(snippet => snippet.type !== 'snippet');
+          } else queryMatchers.push(snippet => snippet.type === type);
+        if (language)
+          queryMatchers.push(
+            snippet => snippet.language && snippet.language.id === language
+          );
+        if (tag)
+          if (primary)
+            queryMatchers.push(snippet => snippet.primaryTag === tag);
+          else queryMatchers.push(snippet => snippet.tags.includes(tag));
+
+        return Snippet.records.where(snippet =>
+          queryMatchers.every(matcher => matcher(snippet))
+        );
+      }
+      return preparedQueriesCache.get(cacheKey);
+    };
+}

--- a/src/blocks/utilities/preparedQueries.js
+++ b/src/blocks/utilities/preparedQueries.js
@@ -36,6 +36,26 @@ export class PreparedQueries {
   };
 
   /**
+   * Returns an array of (type, count) tuples, sorted by count.
+   */
+  static snippetCountByType = application => () => {
+    if (!preparedQueriesCache.has('snippetCountByType')) {
+      const Snippet = application.dataset.getModel('Snippet');
+
+      const groupedRecords = Snippet.records.groupBy('type');
+      const result = Object.fromEntries(
+        Object.keys(groupedRecords).map(type => [
+          type,
+          groupedRecords[type].length,
+        ])
+      );
+
+      preparedQueriesCache.set('snippetCountByType', result);
+    }
+    return preparedQueriesCache.get('snippetCountByType');
+  };
+
+  /**
    * Returns an array of matching snippets based on the given options.
    * @param {string} options.language - Language id
    * @param {string} options.tag - Tag string


### PR DESCRIPTION
Introduce a `PreparedQueries` utility to allow commonly-used queries to be set up in such a way that they can be used from the REPL console quickly and easily. Includes automatic caching to increase performance on long queries.